### PR TITLE
fix: handle LID contacts + pushName

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,14 +112,16 @@ Search contacts by name or phone number.
 
 #### `get_contact`
 
-Resolve a phone number to a contact name.
+Resolve a WhatsApp contact name from a phone number, LID, or full JID.
 
 **Parameters:**
-- `phone` (required): Phone number to look up
+- `identifier` (required): Phone number, LID, or full JID (aliases: `phone_number`, `phone`)
+  - Examples: `12025551234`, `184125298348272`, `12025551234@s.whatsapp.net`, `184125298348272@lid`
 
 **Natural Language Examples:**
 - "What's the name for phone number 5551234567?"
 - "Look up who owns this number"
+- "Who is 184125298348272@lid?"
 
 ### Message Operations
 

--- a/whatsapp-mcp-server/tests/test_get_contact.py
+++ b/whatsapp-mcp-server/tests/test_get_contact.py
@@ -1,0 +1,63 @@
+import main as mcp_main
+
+
+def test_get_contact_normalizes_phone_number(monkeypatch):
+    def fake_get_chat(jid: str, include_last_message: bool = True):
+        assert include_last_message is False
+        return {"jid": jid, "name": "John Doe"}
+
+    monkeypatch.setattr(mcp_main, "whatsapp_get_chat", fake_get_chat)
+    monkeypatch.setattr(mcp_main, "whatsapp_get_sender_name", lambda jid: jid)
+
+    result = mcp_main.get_contact(identifier="12025551234")
+
+    assert result["jid"] == "12025551234@s.whatsapp.net"
+    assert result["is_lid"] is False
+    assert result["phone_number"] == "12025551234"
+    assert result["lid"] is None
+    assert result["name"] == "John Doe"
+    assert result["display_name"] == "John Doe"
+    assert result["resolved"] is True
+
+
+def test_get_contact_normalizes_lid(monkeypatch):
+    def fake_get_chat(jid: str, include_last_message: bool = True):
+        assert include_last_message is False
+        if jid.endswith("@s.whatsapp.net"):
+            return None
+        return {"jid": jid, "name": "Vicky"}
+
+    monkeypatch.setattr(mcp_main, "whatsapp_get_chat", fake_get_chat)
+    monkeypatch.setattr(mcp_main, "whatsapp_get_sender_name", lambda jid: jid)
+
+    result = mcp_main.get_contact(identifier="184125298348272")
+
+    assert result["jid"] == "184125298348272@lid"
+    assert result["is_lid"] is True
+    assert result["phone_number"] is None
+    assert result["lid"] == "184125298348272"
+    assert result["name"] == "Vicky"
+    assert result["display_name"] == "Vicky"
+    assert result["resolved"] is True
+
+
+def test_get_contact_unresolved_falls_back_to_jid_user(monkeypatch):
+    monkeypatch.setattr(mcp_main, "whatsapp_get_chat", lambda *args, **kwargs: None)
+    monkeypatch.setattr(mcp_main, "whatsapp_get_sender_name", lambda jid: jid)
+
+    result = mcp_main.get_contact(identifier="184125298348272@lid")
+
+    assert result["jid"] == "184125298348272@lid"
+    assert result["is_lid"] is True
+    assert result["resolved"] is False
+    assert result["name"] == "184125298348272"
+
+
+def test_get_contact_backward_compatible_phone_number_param(monkeypatch):
+    monkeypatch.setattr(mcp_main, "whatsapp_get_chat", lambda *args, **kwargs: {"name": "John Doe"})
+    monkeypatch.setattr(mcp_main, "whatsapp_get_sender_name", lambda jid: jid)
+
+    result = mcp_main.get_contact(phone_number="12025551234")
+
+    assert result["jid"] == "12025551234@s.whatsapp.net"
+    assert result["name"] == "John Doe"


### PR DESCRIPTION
## Summary
- Update `get_contact` to accept `identifier` (phone, LID, or full JID) with backward-compatible aliases.
- Prefer chat-table name lookup and fall back from `@s.whatsapp.net` to `@lid` for ambiguous 15-digit numeric identifiers.
- Update bridge message handling to use `PushName` when contact lookup yields only numeric IDs.

## Testing
- `cd whatsapp-mcp-server && uv run pytest -v`
- `cd whatsapp-bridge && go test ./...`
