### PR TITLE
fix: resolve phone number JIDs to LIDs before sending

### DIFF
--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -256,13 +256,14 @@ func sendWhatsAppMessage(client *whatsmeow.Client, recipient string, message str
 	if recipientJID.Server == types.DefaultUserServer {
 		ctx := context.Background()
 		lid, lidErr := client.Store.LIDs.GetLIDForPN(ctx, recipientJID)
-		if lidErr != nil {
-			fmt.Printf("Warning: LID lookup failed for %s: %v\n", recipientJID, lidErr)
-		} else if !lid.IsEmpty() {
+		if lidErr == nil && !lid.IsEmpty() {
 			fmt.Printf("Resolved %s -> %s (LID)\n", recipientJID, lid)
 			recipientJID = lid
 		} else {
-			// Not cached locally — ask the WhatsApp server
+			// Cache miss or cache error — ask the WhatsApp server.
+			if lidErr != nil {
+				fmt.Printf("Warning: LID cache lookup failed for %s: %v, falling back to server\n", recipientJID, lidErr)
+			}
 			info, infoErr := client.GetUserInfo(ctx, []types.JID{recipientJID})
 			if infoErr != nil {
 				fmt.Printf("Warning: server LID lookup failed for %s: %v\n", recipientJID, infoErr)


### PR DESCRIPTION
## Summary

- WhatsApp is migrating contacts to LID (Linked Identity) addressing. Messages sent to phone-based JIDs (`user@s.whatsapp.net`) silently fail for migrated contacts — the API returns `{"success": true}` but the message never arrives.
- This adds explicit phone→LID resolution in `sendWhatsAppMessage` before constructing the message. It checks the local whatsmeow LID cache first, then falls back to querying the WhatsApp server via `GetUserInfo`.
- This bypasses the `LIDMigrationTimestamp` gate in whatsmeow's `SendMessage`, which can be `0` if the bridge session was established before the migration event was pushed.

## Context

whatsmeow (v0.0.0-20260107) already has LID resolution built into `SendMessage`, but it's gated behind `Store.LIDMigrationTimestamp > 0`. If that flag isn't set (e.g., the session predates the migration push), resolution is skipped entirely and sends to the phone JID — which WhatsApp silently drops for migrated contacts.

The fix is a ~20-line addition that resolves phone→LID explicitly, regardless of the migration timestamp state.

## Test plan

- [x] Confirmed messages to LID-migrated contacts were silently failing (API returned success, no delivery)
- [x] Verified bridge logs show `Resolved 15550001234@s.whatsapp.net -> 236687108104300@lid (LID)`
- [x] Confirmed message delivery with double-check marks after fix
- [x] `go build` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)