### PR TITLE
fix: migrate legacy @lid chat rows to phone JIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Go compilation errors from whatsmeow API changes (added `context.Background()`)
 - Media filename consistency - now uses message timestamp instead of download time
+- Startup migration now consolidates legacy `@lid` chat/message rows into mapped phone JIDs (`@s.whatsapp.net`) to prevent split chat history
 - golangci.yml configuration (removed deprecated linters)
 - Python linting issues (185 errors fixed)
 - Trailing whitespace in SQL queries

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,8 @@ This is the **whatsapp-mcp** repository - a Model Context Protocol (MCP) server 
 
 Originally forked from [lharries/whatsapp-mcp](https://github.com/lharries/whatsapp-mcp), now maintained by [Very Good Plugins](https://verygoodplugins.com/?utm_source=github).
 
+**Important:** This is the `verygoodplugins/whatsapp-mcp` fork. Always use `origin` (not `upstream`) for PRs, issues, and `gh` commands. The default repo is set via `gh repo set-default verygoodplugins/whatsapp-mcp`.
+
 ## Architecture
 
 ```mermaid

--- a/whatsapp-bridge/.golangci.yml
+++ b/whatsapp-bridge/.golangci.yml
@@ -1,8 +1,6 @@
 # Linting config for whatsapp-bridge
 # staticcheck disabled due to deprecated whatsmeow imports (requires library update)
 
-version: "2"
-
 linters:
   enable:
     - govet

--- a/whatsapp-bridge/.golangci.yml
+++ b/whatsapp-bridge/.golangci.yml
@@ -1,6 +1,8 @@
 # Linting config for whatsapp-bridge
 # staticcheck disabled due to deprecated whatsmeow imports (requires library update)
 
+version: "2"
+
 linters:
   enable:
     - govet

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -171,10 +171,11 @@ func (store *MessageStore) MigrateLegacyLIDChatsToPhoneJIDs(whatsappDBPath strin
 	}
 
 	if _, err := tx.Exec(`
-		CREATE TEMP TABLE tmp_lid_chat_meta AS
+		CREATE TEMP TABLE tmp_lid_chat_candidates AS
 		SELECT
 			m.phone_jid AS phone_jid,
-			COALESCE(NULLIF(TRIM(c.name), ''), substr(m.phone_jid, 1, instr(m.phone_jid, '@') - 1)) AS source_name,
+			m.lid_jid AS lid_jid,
+			NULLIF(TRIM(c.name), '') AS source_name,
 			COALESCE(
 				c.last_message_time,
 				(
@@ -185,6 +186,31 @@ func (store *MessageStore) MigrateLegacyLIDChatsToPhoneJIDs(whatsappDBPath strin
 			) AS source_last_message_time
 		FROM tmp_lid_to_phone m
 		LEFT JOIN chats c ON c.jid = m.lid_jid;
+	`); err != nil {
+		return fmt.Errorf("failed to build temporary chat candidate table: %w", err)
+	}
+
+	if _, err := tx.Exec(`
+		CREATE TEMP TABLE tmp_lid_chat_meta AS
+		SELECT
+			c.phone_jid AS phone_jid,
+			COALESCE(
+				(
+					SELECT c2.source_name
+					FROM tmp_lid_chat_candidates c2
+					WHERE c2.phone_jid = c.phone_jid
+						AND c2.source_name IS NOT NULL
+					ORDER BY
+						CASE WHEN c2.source_last_message_time IS NULL THEN 1 ELSE 0 END,
+						c2.source_last_message_time DESC,
+						c2.lid_jid ASC
+					LIMIT 1
+				),
+				substr(c.phone_jid, 1, instr(c.phone_jid, '@') - 1)
+			) AS source_name,
+			MAX(c.source_last_message_time) AS source_last_message_time
+		FROM tmp_lid_chat_candidates c
+		GROUP BY c.phone_jid;
 	`); err != nil {
 		return fmt.Errorf("failed to build temporary chat metadata table: %w", err)
 	}
@@ -205,7 +231,6 @@ func (store *MessageStore) MigrateLegacyLIDChatsToPhoneJIDs(whatsappDBPath strin
 					SELECT m.source_name
 					FROM tmp_lid_chat_meta m
 					WHERE m.phone_jid = chats.jid
-					LIMIT 1
 				)
 				ELSE name
 			END,
@@ -214,24 +239,20 @@ func (store *MessageStore) MigrateLegacyLIDChatsToPhoneJIDs(whatsappDBPath strin
 					SELECT m.source_last_message_time
 					FROM tmp_lid_chat_meta m
 					WHERE m.phone_jid = chats.jid
-					LIMIT 1
 				) IS NULL THEN last_message_time
 				WHEN last_message_time IS NULL THEN (
 					SELECT m.source_last_message_time
 					FROM tmp_lid_chat_meta m
 					WHERE m.phone_jid = chats.jid
-					LIMIT 1
 				)
 				WHEN (
 					SELECT m.source_last_message_time
 					FROM tmp_lid_chat_meta m
 					WHERE m.phone_jid = chats.jid
-					LIMIT 1
 				) > last_message_time THEN (
 					SELECT m.source_last_message_time
 					FROM tmp_lid_chat_meta m
 					WHERE m.phone_jid = chats.jid
-					LIMIT 1
 				)
 				ELSE last_message_time
 			END
@@ -291,6 +312,9 @@ func (store *MessageStore) MigrateLegacyLIDChatsToPhoneJIDs(whatsappDBPath strin
 	}
 	if _, err := tx.Exec("DROP TABLE IF EXISTS tmp_lid_chat_meta;"); err != nil {
 		return fmt.Errorf("failed to clean temporary chat metadata table: %w", err)
+	}
+	if _, err := tx.Exec("DROP TABLE IF EXISTS tmp_lid_chat_candidates;"); err != nil {
+		return fmt.Errorf("failed to clean temporary chat candidate table: %w", err)
 	}
 
 	if err := tx.Commit(); err != nil {

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -115,6 +115,198 @@ func NewMessageStore() (*MessageStore, error) {
 	return &MessageStore{db: db}, nil
 }
 
+// MigrateLegacyLIDChatsToPhoneJIDs rewrites message/chat rows stored under
+// legacy @lid chat JIDs into phone-based @s.whatsapp.net chat JIDs using the
+// whatsmeow LID map in whatsapp.db.
+func (store *MessageStore) MigrateLegacyLIDChatsToPhoneJIDs(whatsappDBPath string, logger waLog.Logger) error {
+	if _, err := os.Stat(whatsappDBPath); err != nil {
+		if os.IsNotExist(err) {
+			logger.Infof("Skipping LID chat migration: %s not found", whatsappDBPath)
+			return nil
+		}
+		return fmt.Errorf("failed to stat WhatsApp DB %s: %w", whatsappDBPath, err)
+	}
+
+	tx, err := store.db.Begin()
+	if err != nil {
+		return fmt.Errorf("failed to start LID chat migration transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	alias := fmt.Sprintf("wa_mig_%d", time.Now().UnixNano())
+	escapedPath := strings.ReplaceAll(whatsappDBPath, "'", "''")
+	if _, err := tx.Exec(fmt.Sprintf("ATTACH DATABASE '%s' AS %s;", escapedPath, alias)); err != nil {
+		return fmt.Errorf("failed to attach WhatsApp DB for LID chat migration: %w", err)
+	}
+
+	if _, err := tx.Exec(fmt.Sprintf(`
+		CREATE TEMP TABLE tmp_lid_to_phone AS
+		SELECT DISTINCT
+			lm.lid || '@lid' AS lid_jid,
+			lm.pn || '@s.whatsapp.net' AS phone_jid
+		FROM %s.whatsmeow_lid_map lm
+		WHERE lm.lid != '' AND lm.pn != ''
+		  AND (
+		  	EXISTS (SELECT 1 FROM chats c WHERE c.jid = lm.lid || '@lid')
+		  	OR EXISTS (SELECT 1 FROM messages m WHERE m.chat_jid = lm.lid || '@lid')
+		  );
+	`, alias)); err != nil {
+		return fmt.Errorf("failed to build temporary LID mapping table: %w", err)
+	}
+
+	var mappedChats int
+	if err := tx.QueryRow("SELECT COUNT(*) FROM tmp_lid_to_phone;").Scan(&mappedChats); err != nil {
+		return fmt.Errorf("failed to count mapped LID chats: %w", err)
+	}
+
+	if mappedChats == 0 {
+		if _, err := tx.Exec("DROP TABLE IF EXISTS tmp_lid_to_phone;"); err != nil {
+			return fmt.Errorf("failed to clean temporary LID mapping table: %w", err)
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("failed to commit no-op LID chat migration: %w", err)
+		}
+		logger.Infof("LID chat migration: nothing to migrate")
+		return nil
+	}
+
+	if _, err := tx.Exec(`
+		CREATE TEMP TABLE tmp_lid_chat_meta AS
+		SELECT
+			m.phone_jid AS phone_jid,
+			COALESCE(NULLIF(TRIM(c.name), ''), substr(m.phone_jid, 1, instr(m.phone_jid, '@') - 1)) AS source_name,
+			COALESCE(
+				c.last_message_time,
+				(
+					SELECT MAX(msg.timestamp)
+					FROM messages msg
+					WHERE msg.chat_jid = m.lid_jid
+				)
+			) AS source_last_message_time
+		FROM tmp_lid_to_phone m
+		LEFT JOIN chats c ON c.jid = m.lid_jid;
+	`); err != nil {
+		return fmt.Errorf("failed to build temporary chat metadata table: %w", err)
+	}
+
+	if _, err := tx.Exec(`
+		INSERT OR IGNORE INTO chats (jid, name, last_message_time)
+		SELECT phone_jid, source_name, source_last_message_time
+		FROM tmp_lid_chat_meta;
+	`); err != nil {
+		return fmt.Errorf("failed to upsert destination chat rows: %w", err)
+	}
+
+	if _, err := tx.Exec(`
+		UPDATE chats
+		SET
+			name = CASE
+				WHEN (name IS NULL OR TRIM(name) = '') THEN (
+					SELECT m.source_name
+					FROM tmp_lid_chat_meta m
+					WHERE m.phone_jid = chats.jid
+					LIMIT 1
+				)
+				ELSE name
+			END,
+			last_message_time = CASE
+				WHEN (
+					SELECT m.source_last_message_time
+					FROM tmp_lid_chat_meta m
+					WHERE m.phone_jid = chats.jid
+					LIMIT 1
+				) IS NULL THEN last_message_time
+				WHEN last_message_time IS NULL THEN (
+					SELECT m.source_last_message_time
+					FROM tmp_lid_chat_meta m
+					WHERE m.phone_jid = chats.jid
+					LIMIT 1
+				)
+				WHEN (
+					SELECT m.source_last_message_time
+					FROM tmp_lid_chat_meta m
+					WHERE m.phone_jid = chats.jid
+					LIMIT 1
+				) > last_message_time THEN (
+					SELECT m.source_last_message_time
+					FROM tmp_lid_chat_meta m
+					WHERE m.phone_jid = chats.jid
+					LIMIT 1
+				)
+				ELSE last_message_time
+			END
+		WHERE jid IN (SELECT phone_jid FROM tmp_lid_chat_meta);
+	`); err != nil {
+		return fmt.Errorf("failed to merge destination chat metadata: %w", err)
+	}
+
+	insertResult, err := tx.Exec(`
+		INSERT OR IGNORE INTO messages (
+			id, chat_jid, sender, content, timestamp, is_from_me,
+			media_type, filename, url, media_key, file_sha256, file_enc_sha256, file_length
+		)
+		SELECT
+			msg.id,
+			m.phone_jid,
+			msg.sender,
+			msg.content,
+			msg.timestamp,
+			msg.is_from_me,
+			msg.media_type,
+			msg.filename,
+			msg.url,
+			msg.media_key,
+			msg.file_sha256,
+			msg.file_enc_sha256,
+			msg.file_length
+		FROM messages msg
+		JOIN tmp_lid_to_phone m ON m.lid_jid = msg.chat_jid;
+	`)
+	if err != nil {
+		return fmt.Errorf("failed to copy legacy LID messages into phone chats: %w", err)
+	}
+
+	insertedMessages, _ := insertResult.RowsAffected()
+
+	deleteMessagesResult, err := tx.Exec(`
+		DELETE FROM messages
+		WHERE chat_jid IN (SELECT lid_jid FROM tmp_lid_to_phone);
+	`)
+	if err != nil {
+		return fmt.Errorf("failed to delete migrated LID messages: %w", err)
+	}
+	deletedMessages, _ := deleteMessagesResult.RowsAffected()
+
+	deleteChatsResult, err := tx.Exec(`
+		DELETE FROM chats
+		WHERE jid IN (SELECT lid_jid FROM tmp_lid_to_phone);
+	`)
+	if err != nil {
+		return fmt.Errorf("failed to delete migrated LID chats: %w", err)
+	}
+	deletedChats, _ := deleteChatsResult.RowsAffected()
+
+	if _, err := tx.Exec("DROP TABLE IF EXISTS tmp_lid_to_phone;"); err != nil {
+		return fmt.Errorf("failed to clean temporary LID mapping table: %w", err)
+	}
+	if _, err := tx.Exec("DROP TABLE IF EXISTS tmp_lid_chat_meta;"); err != nil {
+		return fmt.Errorf("failed to clean temporary chat metadata table: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit LID chat migration: %w", err)
+	}
+
+	logger.Infof(
+		"LID chat migration complete: mapped_chats=%d inserted_messages=%d deleted_lid_messages=%d deleted_lid_chats=%d",
+		mappedChats,
+		insertedMessages,
+		deletedMessages,
+		deletedChats,
+	)
+	return nil
+}
+
 // Close the database connection
 func (store *MessageStore) Close() error {
 	return store.db.Close()
@@ -1129,6 +1321,11 @@ func main() {
 		return
 	}
 	defer func() { _ = messageStore.Close() }()
+
+	if err := messageStore.MigrateLegacyLIDChatsToPhoneJIDs("store/whatsapp.db", logger); err != nil {
+		logger.Errorf("Failed to migrate legacy LID chat rows: %v", err)
+		return
+	}
 
 	// Channel to signal reconnection needs
 	reconnectChan := make(chan bool, 1)

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -139,6 +139,21 @@ func (store *MessageStore) MigrateLegacyLIDChatsToPhoneJIDs(whatsappDBPath strin
 		return fmt.Errorf("failed to attach WhatsApp DB for LID chat migration: %w", err)
 	}
 
+	var lidMapTableExists int
+	if err := tx.QueryRow(fmt.Sprintf(
+		"SELECT COUNT(1) FROM %s.sqlite_master WHERE type='table' AND name='whatsmeow_lid_map';",
+		alias,
+	)).Scan(&lidMapTableExists); err != nil {
+		return fmt.Errorf("failed to inspect WhatsApp DB schema for LID migration: %w", err)
+	}
+	if lidMapTableExists == 0 {
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("failed to commit no-op LID chat migration: %w", err)
+		}
+		logger.Infof("Skipping LID chat migration: whatsmeow_lid_map table not found")
+		return nil
+	}
+
 	if _, err := tx.Exec(fmt.Sprintf(`
 		CREATE TEMP TABLE tmp_lid_to_phone AS
 		SELECT DISTINCT

--- a/whatsapp-bridge/main_test.go
+++ b/whatsapp-bridge/main_test.go
@@ -314,3 +314,75 @@ func TestMigrateLegacyLIDChatsToPhoneJIDs_MissingWhatsAppDBIsNoOp(t *testing.T) 
 		t.Fatalf("expected missing whatsapp db to be treated as no-op, got error: %v", err)
 	}
 }
+
+func TestMigrateLegacyLIDChatsToPhoneJIDs_AggregatesByPhoneJIDDeterministically(t *testing.T) {
+	ms := newTestMessageStore(t)
+	logger := testLogger()
+
+	tmpDir := t.TempDir()
+	whatsappDBPath := filepath.Join(tmpDir, "whatsapp.db")
+
+	waDB, err := sql.Open("sqlite3", whatsappDBPath)
+	if err != nil {
+		t.Fatalf("failed to create whatsapp db: %v", err)
+	}
+	defer func() { _ = waDB.Close() }()
+
+	if _, err := waDB.Exec(`
+		CREATE TABLE whatsmeow_lid_map (
+			lid TEXT PRIMARY KEY,
+			pn TEXT NOT NULL
+		);
+		INSERT INTO whatsmeow_lid_map (lid, pn) VALUES ('111', '222');
+		INSERT INTO whatsmeow_lid_map (lid, pn) VALUES ('333', '222');
+	`); err != nil {
+		t.Fatalf("failed to prepare lid map db: %v", err)
+	}
+
+	lidA := "111@lid"
+	lidB := "333@lid"
+	phoneJID := "222@s.whatsapp.net"
+
+	_, err = ms.db.Exec(`
+		INSERT INTO chats (jid, name, last_message_time) VALUES
+			(?, 'Older Name', '2026-03-01T10:00:00Z'),
+			(?, 'Newest Name', '2026-03-01T11:00:00Z');
+
+		INSERT INTO messages (id, chat_jid, sender, content, timestamp, is_from_me, media_type, filename, url, media_key, file_sha256, file_enc_sha256, file_length) VALUES
+			('a1', ?, 'alice', 'from lid A', '2026-03-01T10:00:00Z', 0, '', '', '', NULL, NULL, NULL, 0),
+			('b1', ?, 'bob', 'from lid B', '2026-03-01T11:00:00Z', 0, '', '', '', NULL, NULL, NULL, 0);
+	`, lidA, lidB, lidA, lidB)
+	if err != nil {
+		t.Fatalf("failed to seed message store: %v", err)
+	}
+
+	if err := ms.MigrateLegacyLIDChatsToPhoneJIDs(whatsappDBPath, logger); err != nil {
+		t.Fatalf("migration failed: %v", err)
+	}
+
+	if count := queryMessageCount(ms, lidA); count != 0 {
+		t.Fatalf("expected no messages under first LID after migration, got %d", count)
+	}
+	if count := queryMessageCount(ms, lidB); count != 0 {
+		t.Fatalf("expected no messages under second LID after migration, got %d", count)
+	}
+	if count := queryMessageCount(ms, phoneJID); count != 2 {
+		t.Fatalf("expected 2 messages under phone JID after migration, got %d", count)
+	}
+
+	name, found := queryChat(ms, phoneJID)
+	if !found {
+		t.Fatalf("expected merged phone chat row to exist")
+	}
+	if name != "Newest Name" {
+		t.Fatalf("expected deterministic name selection from latest source chat, got %q", name)
+	}
+
+	var lastMessage string
+	if err := ms.db.QueryRow("SELECT last_message_time FROM chats WHERE jid = ?", phoneJID).Scan(&lastMessage); err != nil {
+		t.Fatalf("failed to read merged last_message_time: %v", err)
+	}
+	if lastMessage != "2026-03-01T11:00:00Z" {
+		t.Fatalf("expected merged last_message_time to be max source value, got %s", lastMessage)
+	}
+}

--- a/whatsapp-bridge/main_test.go
+++ b/whatsapp-bridge/main_test.go
@@ -75,7 +75,7 @@ func newTestMessageStore(t *testing.T) *MessageStore {
 	if err != nil {
 		t.Fatalf("failed to create tables: %v", err)
 	}
-	t.Cleanup(func() { db.Close() })
+	t.Cleanup(func() { _ = db.Close() })
 	return &MessageStore{db: db}
 }
 
@@ -108,6 +108,12 @@ func buildTextMessage(chat, sender, senderAlt, recipientAlt types.JID, isFromMe 
 func queryChat(ms *MessageStore, jid string) (name string, found bool) {
 	err := ms.db.QueryRow("SELECT name FROM chats WHERE jid = ?", jid).Scan(&name)
 	return name, err == nil
+}
+
+// queryChatLastMessageTime returns the last_message_time for a chat JID.
+func queryChatLastMessageTime(ms *MessageStore, jid string) (lastMessageTime string, found bool) {
+	err := ms.db.QueryRow("SELECT last_message_time FROM chats WHERE jid = ?", jid).Scan(&lastMessageTime)
+	return lastMessageTime, err == nil
 }
 
 // queryMessageCount returns the number of messages stored under a chat JID.
@@ -295,6 +301,14 @@ func TestMigrateLegacyLIDChatsToPhoneJIDs_MigratesAndIsIdempotent(t *testing.T) 
 	}
 	if phoneName != "Legacy LID Name" {
 		t.Fatalf("expected phone chat name to be hydrated from LID chat, got %q", phoneName)
+	}
+
+	phoneTime, timeFound := queryChatLastMessageTime(ms, phoneJID)
+	if !timeFound {
+		t.Fatalf("expected phone chat to have last_message_time after migration")
+	}
+	if phoneTime != "2026-03-01T10:00:00Z" {
+		t.Fatalf("expected phone chat last_message_time to be the latest (from LID chat), got %q", phoneTime)
 	}
 
 	if err := ms.MigrateLegacyLIDChatsToPhoneJIDs(whatsappDBPath, logger); err != nil {

--- a/whatsapp-bridge/main_test.go
+++ b/whatsapp-bridge/main_test.go
@@ -3,16 +3,17 @@ package main
 import (
 	"context"
 	"database/sql"
+	"path/filepath"
 	"testing"
 	"time"
 
 	_ "github.com/mattn/go-sqlite3"
 	"go.mau.fi/whatsmeow"
+	waProto "go.mau.fi/whatsmeow/binary/proto"
 	"go.mau.fi/whatsmeow/store"
 	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
 	waLog "go.mau.fi/whatsmeow/util/log"
-	waProto "go.mau.fi/whatsmeow/binary/proto"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -131,11 +132,11 @@ func TestHandleMessage_IncomingLIDMessage_StoredUnderPhoneJID(t *testing.T) {
 	logger := testLogger()
 
 	msg := buildTextMessage(
-		phoneLID,        // chat: arrives as LID
-		phoneLID,        // sender: LID
-		phonePN,         // senderAlt: phone JID (provided by whatsmeow)
-		types.EmptyJID,  // recipientAlt: not set for incoming
-		false,           // isFromMe: incoming
+		phoneLID,       // chat: arrives as LID
+		phoneLID,       // sender: LID
+		phonePN,        // senderAlt: phone JID (provided by whatsmeow)
+		types.EmptyJID, // recipientAlt: not set for incoming
+		false,          // isFromMe: incoming
 		"Hola, qué tal?",
 	)
 
@@ -163,11 +164,11 @@ func TestHandleMessage_OutgoingLIDMessage_StoredUnderPhoneJID(t *testing.T) {
 	logger := testLogger()
 
 	msg := buildTextMessage(
-		phoneLID,        // chat: LID
-		phoneLID,        // sender: self (LID)
-		types.EmptyJID,  // senderAlt: not set for outgoing
-		phonePN,         // recipientAlt: phone JID
-		true,            // isFromMe: outgoing
+		phoneLID,       // chat: LID
+		phoneLID,       // sender: self (LID)
+		types.EmptyJID, // senderAlt: not set for outgoing
+		phonePN,        // recipientAlt: phone JID
+		true,           // isFromMe: outgoing
 		"Todo bien!",
 	)
 
@@ -192,11 +193,11 @@ func TestHandleMessage_LIDWithStoreFallback_StoredUnderPhoneJID(t *testing.T) {
 
 	// No SenderAlt/RecipientAlt -- must resolve via LID store.
 	msg := buildTextMessage(
-		phoneLID,        // chat: LID
-		phoneLID,        // sender: LID
-		types.EmptyJID,  // senderAlt: empty (simulates missing alt)
-		types.EmptyJID,  // recipientAlt: empty
-		false,           // isFromMe: incoming
+		phoneLID,       // chat: LID
+		phoneLID,       // sender: LID
+		types.EmptyJID, // senderAlt: empty (simulates missing alt)
+		types.EmptyJID, // recipientAlt: empty
+		false,          // isFromMe: incoming
 		"Message without alt JIDs",
 	)
 
@@ -217,11 +218,11 @@ func TestHandleMessage_PhoneJID_Unaffected(t *testing.T) {
 	logger := testLogger()
 
 	msg := buildTextMessage(
-		phonePN,         // chat: already phone-based
-		phonePN,         // sender: phone-based
-		types.EmptyJID,  // senderAlt: empty
-		types.EmptyJID,  // recipientAlt: empty
-		false,           // isFromMe: incoming
+		phonePN,        // chat: already phone-based
+		phonePN,        // sender: phone-based
+		types.EmptyJID, // senderAlt: empty
+		types.EmptyJID, // recipientAlt: empty
+		false,          // isFromMe: incoming
 		"Normal message",
 	)
 
@@ -229,5 +230,87 @@ func TestHandleMessage_PhoneJID_Unaffected(t *testing.T) {
 
 	if count := queryMessageCount(ms, phonePN.String()); count != 1 {
 		t.Errorf("expected 1 message under phone JID %s, got %d", phonePN, count)
+	}
+}
+
+func TestMigrateLegacyLIDChatsToPhoneJIDs_MigratesAndIsIdempotent(t *testing.T) {
+	ms := newTestMessageStore(t)
+	logger := testLogger()
+
+	tmpDir := t.TempDir()
+	whatsappDBPath := filepath.Join(tmpDir, "whatsapp.db")
+
+	waDB, err := sql.Open("sqlite3", whatsappDBPath)
+	if err != nil {
+		t.Fatalf("failed to create whatsapp db: %v", err)
+	}
+	defer func() { _ = waDB.Close() }()
+
+	if _, err := waDB.Exec(`
+		CREATE TABLE whatsmeow_lid_map (
+			lid TEXT PRIMARY KEY,
+			pn TEXT NOT NULL
+		);
+		INSERT INTO whatsmeow_lid_map (lid, pn) VALUES ('111', '222');
+	`); err != nil {
+		t.Fatalf("failed to prepare lid map db: %v", err)
+	}
+
+	lidJID := "111@lid"
+	phoneJID := "222@s.whatsapp.net"
+
+	_, err = ms.db.Exec(`
+		INSERT INTO chats (jid, name, last_message_time) VALUES
+			(?, 'Legacy LID Name', '2026-03-01T10:00:00Z'),
+			(?, '', '2026-03-01T09:00:00Z');
+
+		INSERT INTO messages (id, chat_jid, sender, content, timestamp, is_from_me, media_type, filename, url, media_key, file_sha256, file_enc_sha256, file_length) VALUES
+			('dup', ?, 'alice', 'lid duplicate', '2026-03-01T10:00:00Z', 0, '', '', '', NULL, NULL, NULL, 0),
+			('only-lid', ?, 'alice', 'lid only', '2026-03-01T10:01:00Z', 0, '', '', '', NULL, NULL, NULL, 0),
+			('dup', ?, 'alice', 'phone duplicate', '2026-03-01T10:00:00Z', 0, '', '', '', NULL, NULL, NULL, 0),
+			('only-phone', ?, 'alice', 'phone only', '2026-03-01T10:02:00Z', 0, '', '', '', NULL, NULL, NULL, 0);
+	`, lidJID, phoneJID, lidJID, lidJID, phoneJID, phoneJID)
+	if err != nil {
+		t.Fatalf("failed to seed message store: %v", err)
+	}
+
+	if err := ms.MigrateLegacyLIDChatsToPhoneJIDs(whatsappDBPath, logger); err != nil {
+		t.Fatalf("migration failed: %v", err)
+	}
+
+	if lidCount := queryMessageCount(ms, lidJID); lidCount != 0 {
+		t.Fatalf("expected 0 messages under migrated LID chat, got %d", lidCount)
+	}
+	if phoneCount := queryMessageCount(ms, phoneJID); phoneCount != 3 {
+		t.Fatalf("expected 3 messages under phone chat after dedupe, got %d", phoneCount)
+	}
+
+	if _, found := queryChat(ms, lidJID); found {
+		t.Fatalf("expected migrated LID chat row to be removed")
+	}
+
+	phoneName, found := queryChat(ms, phoneJID)
+	if !found {
+		t.Fatalf("expected phone chat row to exist after migration")
+	}
+	if phoneName != "Legacy LID Name" {
+		t.Fatalf("expected phone chat name to be hydrated from LID chat, got %q", phoneName)
+	}
+
+	if err := ms.MigrateLegacyLIDChatsToPhoneJIDs(whatsappDBPath, logger); err != nil {
+		t.Fatalf("second migration run should be a no-op, got error: %v", err)
+	}
+	if phoneCount := queryMessageCount(ms, phoneJID); phoneCount != 3 {
+		t.Fatalf("expected idempotent result with 3 phone messages, got %d", phoneCount)
+	}
+}
+
+func TestMigrateLegacyLIDChatsToPhoneJIDs_MissingWhatsAppDBIsNoOp(t *testing.T) {
+	ms := newTestMessageStore(t)
+	logger := testLogger()
+
+	missingPath := filepath.Join(t.TempDir(), "missing-whatsapp.db")
+	if err := ms.MigrateLegacyLIDChatsToPhoneJIDs(missingPath, logger); err != nil {
+		t.Fatalf("expected missing whatsapp db to be treated as no-op, got error: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- add a startup migration in `MessageStore` to consolidate legacy `@lid` chat rows into mapped phone JIDs (`@s.whatsapp.net`) using `whatsmeow_lid_map`
- merge chat metadata safely (hydrate blank names, preserve latest `last_message_time`)
- copy messages with `INSERT OR IGNORE` for dedupe, then delete migrated `@lid` chat/message rows
- make migration idempotent and no-op when `store/whatsapp.db` is missing or no mapped legacy rows exist
- document behavior in `CHANGELOG.md`

## Why
PR #12 changed new writes to phone JIDs. Existing databases can still contain legacy `@lid` rows, which causes split history. This migration repairs existing data at startup.

## Verification
- `cd whatsapp-bridge && go test ./...`
- `cd whatsapp-mcp-server && uv run pytest -q`

Both passed locally.

## Tests Added
- `TestMigrateLegacyLIDChatsToPhoneJIDs_MigratesAndIsIdempotent`
- `TestMigrateLegacyLIDChatsToPhoneJIDs_MissingWhatsAppDBIsNoOp`
