### PR TITLE
ci: modernize linting and add release workflow for first fork release

### DIFF
--- a/.github/scripts/check_versions.py
+++ b/.github/scripts/check_versions.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Validate project version consistency for release and CI checks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def read_pyproject_version() -> str:
+    pyproject_path = ROOT / "whatsapp-mcp-server" / "pyproject.toml"
+    data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    return data["project"]["version"]
+
+
+def read_server_json_versions() -> tuple[str, str]:
+    server_json_path = ROOT / "server.json"
+    data = json.loads(server_json_path.read_text(encoding="utf-8"))
+
+    server_version = data["version"]
+    package_version = None
+    for pkg in data.get("packages", []):
+        if pkg.get("registryType") == "pypi" and pkg.get("identifier") == "whatsapp-mcp-server":
+            package_version = pkg.get("version")
+            break
+
+    if not package_version:
+        raise ValueError("server.json is missing the whatsapp-mcp-server PyPI package version")
+
+    return server_version, package_version
+
+
+def normalize_tag(tag: str) -> str:
+    value = tag.strip()
+    if value.startswith("refs/tags/"):
+        value = value[len("refs/tags/") :]
+
+    if not re.fullmatch(r"v\d+\.\d+\.\d+", value):
+        raise ValueError(f"tag must match vMAJOR.MINOR.PATCH, got: {tag!r}")
+
+    return value[1:]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check version consistency across release files.")
+    parser.add_argument("--tag", help="Release tag in vMAJOR.MINOR.PATCH format", default="")
+    args = parser.parse_args()
+
+    pyproject_version = read_pyproject_version()
+    server_version, package_version = read_server_json_versions()
+
+    errors: list[str] = []
+    if pyproject_version != server_version:
+        errors.append(
+            f"Version mismatch: whatsapp-mcp-server/pyproject.toml={pyproject_version} "
+            f"!= server.json.version={server_version}"
+        )
+    if pyproject_version != package_version:
+        errors.append(
+            f"Version mismatch: whatsapp-mcp-server/pyproject.toml={pyproject_version} "
+            f"!= server.json.packages[whatsapp-mcp-server].version={package_version}"
+        )
+
+    tag = args.tag.strip()
+    if tag:
+        tag_version = normalize_tag(tag)
+        if pyproject_version != tag_version:
+            errors.append(
+                f"Version mismatch: tag={tag_version} != whatsapp-mcp-server/pyproject.toml={pyproject_version}"
+            )
+
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    print(
+        "Version check passed: "
+        f"pyproject={pyproject_version}, server.json={server_version}, package={package_version}"
+        + (f", tag={normalize_tag(tag)}" if tag else "")
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/check_versions.py
+++ b/.github/scripts/check_versions.py
@@ -69,12 +69,17 @@ def main() -> int:
         )
 
     tag = args.tag.strip()
+    normalized_tag = ""
     if tag:
-        tag_version = normalize_tag(tag)
-        if pyproject_version != tag_version:
-            errors.append(
-                f"Version mismatch: tag={tag_version} != whatsapp-mcp-server/pyproject.toml={pyproject_version}"
-            )
+        try:
+            normalized_tag = normalize_tag(tag)
+        except ValueError as exc:
+            errors.append(f"Invalid tag format: {tag}: {exc}")
+        else:
+            if pyproject_version != normalized_tag:
+                errors.append(
+                    f"Version mismatch: tag={normalized_tag} != whatsapp-mcp-server/pyproject.toml={pyproject_version}"
+                )
 
     if errors:
         for error in errors:
@@ -84,7 +89,7 @@ def main() -> int:
     print(
         "Version check passed: "
         f"pyproject={pyproject_version}, server.json={server_version}, package={package_version}"
-        + (f", tag={normalize_tag(tag)}" if tag else "")
+        + (f", tag={normalized_tag}" if normalized_tag else "")
     )
     return 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,17 @@ on:
   workflow_dispatch:
 
 jobs:
+  version-consistency:
+    name: Version Consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Validate project versions are in sync
+        run: python .github/scripts/check_versions.py
+
   python-lint:
     name: Python Lint
     runs-on: ubuntu-latest
@@ -37,8 +48,9 @@ jobs:
         with:
           go-version: '1.24'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
+          version: v2.7.1
           working-directory: whatsapp-bridge
 
   go-build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
           mkdir -p dist
 
           cd whatsapp-bridge
-          go build -o ../dist/whatsapp-bridge-linux-amd64 .
+          GOOS=linux GOARCH=amd64 go build -o ../dist/whatsapp-bridge-linux-amd64 .
           cd ..
 
           cd whatsapp-mcp-server
@@ -99,7 +99,7 @@ jobs:
           cd ..
 
           cd dist
-          shasum -a 256 * > SHA256SUMS.txt
+          sha256sum * > SHA256SUMS.txt
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,108 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Optional tag to validate (vMAJOR.MINOR.PATCH)"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  validate-release:
+    name: Validate Release Inputs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Validate version consistency
+        shell: bash
+        run: |
+          TAG="${{ github.event.inputs.tag }}"
+          if [ -z "$TAG" ] && [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            TAG="${GITHUB_REF_NAME}"
+          fi
+
+          if [ -n "$TAG" ]; then
+            python .github/scripts/check_versions.py --tag "$TAG"
+          else
+            python .github/scripts/check_versions.py
+          fi
+
+      - name: Verify golangci configuration
+        run: |
+          cd whatsapp-bridge
+          go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.7.1 config verify
+
+      - name: Run Go lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.7.1
+          working-directory: whatsapp-bridge
+
+      - name: Run Go tests
+        run: |
+          cd whatsapp-bridge
+          go test ./...
+
+      - name: Build Go bridge
+        run: |
+          cd whatsapp-bridge
+          go build -v ./...
+
+      - name: Run Python tests
+        run: |
+          cd whatsapp-mcp-server
+          uv sync --extra dev
+          uv run pytest -q
+
+  publish-github-release:
+    name: Publish GitHub Release
+    needs: validate-release
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Build release artifacts
+        run: |
+          mkdir -p dist
+
+          cd whatsapp-bridge
+          go build -o ../dist/whatsapp-bridge-linux-amd64 .
+          cd ..
+
+          cd whatsapp-mcp-server
+          uv build --out-dir ../dist
+          cd ..
+
+          cd dist
+          shasum -a 256 * > SHA256SUMS.txt
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Infrastructure:**
 - CI/CD pipeline with GitHub Actions (lint, build, test)
+- Tag-based GitHub release workflow with validated artifacts (`.github/workflows/release.yml`)
+- Version consistency check across `pyproject.toml`, `server.json`, and release tags
 - Comprehensive documentation (README, CLAUDE.md)
+- Maintainer release playbook (`docs/RELEASING.md`)
 - Environment variable examples (`.env.example`)
 
 ### Fixed
@@ -48,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Upgraded whatsmeow to latest version (v0.0.0-20260107124630)
+- Upgraded Go linting pipeline to golangci-lint v2 (CI action + v2 config schema)
 - Modernized Python type hints (`Optional[str]` → `str | None`)
 - Improved docstrings with date format examples
 - Media download uses message timestamp for consistent filenames

--- a/README.md
+++ b/README.md
@@ -364,7 +364,14 @@ go build -o whatsapp-bridge
 
 # Run the binary
 ./whatsapp-bridge
+
+# During development (avoids stale binaries)
+go run .
 ```
+
+### Releasing (Maintainers)
+
+Release process and CI/CD details live in [docs/RELEASING.md](docs/RELEASING.md).
 
 ## Troubleshooting
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,42 @@
+# Releasing (Maintainers)
+
+This fork uses tag-driven releases and version consistency checks in CI.
+
+## 1) Prepare release commit
+
+1. Update `CHANGELOG.md`:
+   - Move relevant entries from `Unreleased` into a new version section.
+2. Bump version in both files:
+   - `whatsapp-mcp-server/pyproject.toml` (`project.version`)
+   - `server.json` (`version` and `packages[].version` for `whatsapp-mcp-server`)
+3. Ensure PR CI is green.
+
+## 2) Tag the release
+
+Use semantic version tags in the format `vMAJOR.MINOR.PATCH`.
+
+```bash
+git checkout main
+git pull --ff-only origin main
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+## 3) What CI does on tag push
+
+Workflow: `.github/workflows/release.yml`
+
+- Validates versions are in sync (and match tag)
+- Verifies Go lint config + runs lint/tests/build
+- Runs Python tests
+- Builds artifacts:
+  - `whatsapp-bridge-linux-amd64`
+  - Python wheel + sdist for `whatsapp-mcp-server`
+  - `SHA256SUMS.txt`
+- Creates a GitHub release and uploads artifacts
+
+## 4) Optional: manual validation without publishing
+
+Run the release workflow manually (`workflow_dispatch`) from GitHub Actions.
+You can pass `tag` to validate a candidate version format and file consistency
+without pushing a tag.

--- a/whatsapp-bridge/.golangci.yml
+++ b/whatsapp-bridge/.golangci.yml
@@ -1,14 +1,12 @@
-# Linting config for whatsapp-bridge
-# staticcheck disabled due to deprecated whatsmeow imports (requires library update)
+version: "2"
 
 linters:
+  default: none
   enable:
-    - govet
     - errcheck
-    - unused
+    - govet
     - ineffassign
-  disable:
-    - staticcheck   # Deprecated whatsmeow imports (need library update)
+    - unused
 
 run:
   timeout: 5m


### PR DESCRIPTION
## Summary
- migrate Go linting to golangci-lint v2:
  - `.github/workflows/ci.yml` now uses `golangci/golangci-lint-action@v7`
  - pin lint engine to `v2.7.1`
  - migrate `whatsapp-bridge/.golangci.yml` to v2 schema (`version: "2"`, explicit enable list)
- add CI guardrail for release hygiene:
  - new `Version Consistency` job in CI
  - new script `.github/scripts/check_versions.py` to enforce version sync across:
    - `whatsapp-mcp-server/pyproject.toml`
    - `server.json` root version
    - `server.json` package version
    - optional release tag (`vMAJOR.MINOR.PATCH`)
- add tag-driven release workflow `.github/workflows/release.yml`:
  - validates version consistency
  - verifies lint config and runs lint/tests/build
  - builds artifacts (Go bridge binary + Python wheel/sdist + SHA256SUMS)
  - publishes GitHub Release on tag pushes (`v*.*.*`)
- add maintainer release docs at `docs/RELEASING.md`
- update README and changelog with release/CI updates

## Validation
- `cd whatsapp-bridge && golangci-lint config verify`
- `cd whatsapp-bridge && golangci-lint run ./...`
- `cd whatsapp-bridge && go test ./...`
- `cd whatsapp-mcp-server && uv run pytest -q`
- `python .github/scripts/check_versions.py`
- `python .github/scripts/check_versions.py --tag v0.1.0`

All passed locally.
