### PR TITLE
fix: contact name resolution + configurable bind address

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Copy `.env.example` to `.env` and configure as needed:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
+| `WHATSAPP_BRIDGE_HOST` | `127.0.0.1` | Bind address for Go bridge REST API |
 | `WHATSAPP_BRIDGE_PORT` | `8080` | Port for Go bridge REST API |
 | `WEBHOOK_URL` | `http://localhost:8769/whatsapp/webhook` | Webhook for incoming messages |
 | `FORWARD_SELF` | `false` | Forward messages sent by self |

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -780,17 +780,7 @@ func handleMessage(client *whatsmeow.Client, messageStore *MessageStore, msg *ev
 	sender := msg.Info.Sender.User
 
 	// Get appropriate chat name (pass resolved JID so contact lookup works)
-	name := GetChatName(client, messageStore, resolvedChat, chatJID, nil, sender, logger)
-
-	// If contact resolution fails (common for LIDs), PushName is often the best available display name.
-	// Only apply for direct messages (not groups) and only when the stored name is the numeric JID user.
-	if !msg.Info.IsFromMe && msg.Info.Chat.Server != "g.us" && strings.TrimSpace(msg.Info.PushName) != "" {
-		pushName := strings.TrimSpace(msg.Info.PushName)
-		if name == "" || name == msg.Info.Chat.User {
-			logger.Infof("Updating chat name from PushName for %s: %s -> %s", chatJID, name, pushName)
-			name = pushName
-		}
-	}
+	name := GetChatName(client, messageStore, resolvedChat, chatJID, nil, sender, strings.TrimSpace(msg.Info.PushName), logger)
 
 	// Update chat in database with the message timestamp (keeps last message time updated)
 	err := messageStore.StoreChat(chatJID, name, msg.Info.Timestamp)
@@ -1592,15 +1582,49 @@ connectionSuccess:
 	client.Disconnect()
 }
 
+// resolveContactName resolves a contact's display name from the whatsmeow contact store,
+// trying FullName, then PushName, then BusinessName.
+func resolveContactName(client *whatsmeow.Client, jid types.JID, logger waLog.Logger) string {
+	contact, err := client.Store.Contacts.GetContact(context.Background(), jid)
+	if err != nil {
+		logger.Debugf("GetContact failed for %s: %v", jid, err)
+		return ""
+	}
+	if !contact.Found {
+		logger.Debugf("Contact not found in store for %s", jid)
+		return ""
+	}
+	if contact.FullName != "" {
+		return contact.FullName
+	}
+	if contact.PushName != "" {
+		return contact.PushName
+	}
+	if contact.BusinessName != "" {
+		return contact.BusinessName
+	}
+	return ""
+}
+
 // GetChatName determines the appropriate name for a chat based on JID and other info
-func GetChatName(client *whatsmeow.Client, messageStore *MessageStore, jid types.JID, chatJID string, conversation interface{}, sender string, logger waLog.Logger) string {
+func GetChatName(client *whatsmeow.Client, messageStore *MessageStore, jid types.JID, chatJID string, conversation interface{}, sender string, pushName string, logger waLog.Logger) string {
 	// First, check if chat already exists in database with a name
 	var existingName string
 	err := messageStore.db.QueryRow("SELECT name FROM chats WHERE jid = ?", chatJID).Scan(&existingName)
 	if err == nil && existingName != "" {
-		// Chat exists with a name, use that
-		logger.Infof("Using existing chat name for %s: %s", chatJID, existingName)
-		return existingName
+		// If the name is purely numeric, it's likely a phone number — try to resolve a proper name
+		isNumeric := true
+		for _, r := range existingName {
+			if r < '0' || r > '9' {
+				isNumeric = false
+				break
+			}
+		}
+		if !isNumeric {
+			logger.Infof("Using existing chat name for %s: %s", chatJID, existingName)
+			return existingName
+		}
+		logger.Infof("Existing name for %s is numeric (%s), attempting re-resolution", chatJID, existingName)
 	}
 
 	// Need to determine chat name
@@ -1657,15 +1681,14 @@ func GetChatName(client *whatsmeow.Client, messageStore *MessageStore, jid types
 		// This is an individual contact
 		logger.Infof("Getting name for contact: %s", chatJID)
 
-		// Just use contact info (full name)
-		contact, err := client.Store.Contacts.GetContact(context.Background(), jid)
-		if err == nil && contact.FullName != "" {
-			name = contact.FullName
-		} else if sender != "" {
-			// Fallback to sender
+		name = resolveContactName(client, jid, logger)
+		if name == "" && pushName != "" {
+			name = pushName
+		}
+		if name == "" && sender != "" {
 			name = sender
-		} else {
-			// Last fallback to JID
+		}
+		if name == "" {
 			name = jid.User
 		}
 
@@ -1702,7 +1725,7 @@ func handleHistorySync(client *whatsmeow.Client, messageStore *MessageStore, his
 		chatJID := resolved.String()
 
 		// Get appropriate chat name by passing the history sync conversation directly
-		name := GetChatName(client, messageStore, resolved, chatJID, conversation, "", logger)
+		name := GetChatName(client, messageStore, resolved, chatJID, conversation, "", "", logger)
 
 		// Process messages
 		messages := conversation.Messages

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -1289,7 +1289,7 @@ func startRESTServer(client *whatsmeow.Client, messageStore *MessageStore, host 
 	})
 
 	// Start the server with proper timeouts
-	serverAddr := fmt.Sprintf("%s:%d", host, port)
+	serverAddr := net.JoinHostPort(host, strconv.Itoa(port))
 	fmt.Printf("Starting REST API server on %s...\n", serverAddr)
 
 	// Create server with timeouts for stability

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -780,7 +780,13 @@ func handleMessage(client *whatsmeow.Client, messageStore *MessageStore, msg *ev
 	sender := msg.Info.Sender.User
 
 	// Get appropriate chat name (pass resolved JID so contact lookup works)
-	name := GetChatName(client, messageStore, resolvedChat, chatJID, nil, sender, strings.TrimSpace(msg.Info.PushName), logger)
+	// Only use PushName for incoming messages — for outgoing messages, PushName is
+	// our own name, not the recipient's, which would incorrectly label the chat.
+	var pushName string
+	if !msg.Info.IsFromMe {
+		pushName = strings.TrimSpace(msg.Info.PushName)
+	}
+	name := GetChatName(client, messageStore, resolvedChat, chatJID, nil, sender, pushName, logger)
 
 	// Update chat in database with the message timestamp (keeps last message time updated)
 	err := messageStore.StoreChat(chatJID, name, msg.Info.Timestamp)

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -1084,7 +1085,7 @@ func extractDirectPathFromURL(url string) string {
 }
 
 // Start a REST API server to expose the WhatsApp client functionality
-func startRESTServer(client *whatsmeow.Client, messageStore *MessageStore, port int) {
+func startRESTServer(client *whatsmeow.Client, messageStore *MessageStore, host string, port int) {
 	// Health check endpoint
 	http.HandleFunc("/api/health", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -1288,7 +1289,7 @@ func startRESTServer(client *whatsmeow.Client, messageStore *MessageStore, port 
 	})
 
 	// Start the server with proper timeouts
-	serverAddr := fmt.Sprintf(":%d", port)
+	serverAddr := fmt.Sprintf("%s:%d", host, port)
 	fmt.Printf("Starting REST API server on %s...\n", serverAddr)
 
 	// Create server with timeouts for stability
@@ -1514,6 +1515,14 @@ connectionSuccess:
 	fmt.Println("\n✓ Connected to WhatsApp! Type 'help' for commands.")
 
 	// Start REST API server
+	host := "127.0.0.1" // secure default: bridge exposes private WhatsApp messages
+	if h := os.Getenv("WHATSAPP_BRIDGE_HOST"); h != "" {
+		if net.ParseIP(h) == nil {
+			logger.Errorf("Invalid WHATSAPP_BRIDGE_HOST=%q, must be a valid IP address", h)
+			return
+		}
+		host = h
+	}
 	port := 8080
 	if p := os.Getenv("WHATSAPP_BRIDGE_PORT"); p != "" {
 		v, err := strconv.Atoi(p)
@@ -1523,7 +1532,7 @@ connectionSuccess:
 		}
 		port = v
 	}
-	startRESTServer(client, messageStore, port)
+	startRESTServer(client, messageStore, host, port)
 
 	// Create a channel to keep the main goroutine alive
 	exitChan := make(chan os.Signal, 1)

--- a/whatsapp-bridge/main_test.go
+++ b/whatsapp-bridge/main_test.go
@@ -32,12 +32,27 @@ func (m *mockLIDStore) GetPNForLID(_ context.Context, lid types.JID) (types.JID,
 	return types.EmptyJID, nil
 }
 
-func newTestClient(lidStore store.LIDStore) *whatsmeow.Client {
-	noop := &store.NoopStore{}
+// mockContactStore implements store.ContactStore with an in-memory map.
+type mockContactStore struct {
+	store.NoopStore
+	contacts map[types.JID]types.ContactInfo
+}
+
+func (m *mockContactStore) GetContact(_ context.Context, user types.JID) (types.ContactInfo, error) {
+	if info, ok := m.contacts[user]; ok {
+		return info, nil
+	}
+	return types.ContactInfo{}, nil
+}
+
+func newTestClient(lidStore store.LIDStore, contactStore store.ContactStore) *whatsmeow.Client {
+	if contactStore == nil {
+		contactStore = &store.NoopStore{}
+	}
 	return &whatsmeow.Client{
 		Store: &store.Device{
 			LIDs:     lidStore,
-			Contacts: noop,
+			Contacts: contactStore,
 		},
 	}
 }
@@ -133,7 +148,7 @@ var (
 // --- Integration tests: handleMessage stores under correct JID ---
 
 func TestHandleMessage_IncomingLIDMessage_StoredUnderPhoneJID(t *testing.T) {
-	client := newTestClient(&mockLIDStore{})
+	client := newTestClient(&mockLIDStore{}, nil)
 	ms := newTestMessageStore(t)
 	logger := testLogger()
 
@@ -165,7 +180,7 @@ func TestHandleMessage_IncomingLIDMessage_StoredUnderPhoneJID(t *testing.T) {
 }
 
 func TestHandleMessage_OutgoingLIDMessage_StoredUnderPhoneJID(t *testing.T) {
-	client := newTestClient(&mockLIDStore{})
+	client := newTestClient(&mockLIDStore{}, nil)
 	ms := newTestMessageStore(t)
 	logger := testLogger()
 
@@ -193,7 +208,7 @@ func TestHandleMessage_LIDWithStoreFallback_StoredUnderPhoneJID(t *testing.T) {
 	lidStore := &mockLIDStore{
 		pnByLID: map[types.JID]types.JID{phoneLID: phonePN},
 	}
-	client := newTestClient(lidStore)
+	client := newTestClient(lidStore, nil)
 	ms := newTestMessageStore(t)
 	logger := testLogger()
 
@@ -219,7 +234,7 @@ func TestHandleMessage_LIDWithStoreFallback_StoredUnderPhoneJID(t *testing.T) {
 }
 
 func TestHandleMessage_PhoneJID_Unaffected(t *testing.T) {
-	client := newTestClient(&mockLIDStore{})
+	client := newTestClient(&mockLIDStore{}, nil)
 	ms := newTestMessageStore(t)
 	logger := testLogger()
 
@@ -398,5 +413,125 @@ func TestMigrateLegacyLIDChatsToPhoneJIDs_AggregatesByPhoneJIDDeterministically(
 	}
 	if lastMessage != "2026-03-01T11:00:00Z" {
 		t.Fatalf("expected merged last_message_time to be max source value, got %s", lastMessage)
+	}
+}
+
+// --- Tests for resolveContactName ---
+
+func TestResolveContactName_FullName(t *testing.T) {
+	cs := &mockContactStore{contacts: map[types.JID]types.ContactInfo{
+		phonePN: {Found: true, FullName: "John Doe", PushName: "Johnny"},
+	}}
+	client := newTestClient(&mockLIDStore{}, cs)
+	name := resolveContactName(client, phonePN, testLogger())
+	if name != "John Doe" {
+		t.Errorf("expected 'John Doe', got %q", name)
+	}
+}
+
+func TestResolveContactName_PushNameFallback(t *testing.T) {
+	cs := &mockContactStore{contacts: map[types.JID]types.ContactInfo{
+		phonePN: {Found: true, PushName: "Johnny"},
+	}}
+	client := newTestClient(&mockLIDStore{}, cs)
+	name := resolveContactName(client, phonePN, testLogger())
+	if name != "Johnny" {
+		t.Errorf("expected 'Johnny', got %q", name)
+	}
+}
+
+func TestResolveContactName_BusinessNameFallback(t *testing.T) {
+	cs := &mockContactStore{contacts: map[types.JID]types.ContactInfo{
+		phonePN: {Found: true, BusinessName: "Acme Corp"},
+	}}
+	client := newTestClient(&mockLIDStore{}, cs)
+	name := resolveContactName(client, phonePN, testLogger())
+	if name != "Acme Corp" {
+		t.Errorf("expected 'Acme Corp', got %q", name)
+	}
+}
+
+func TestResolveContactName_NotFound(t *testing.T) {
+	cs := &mockContactStore{contacts: map[types.JID]types.ContactInfo{}}
+	client := newTestClient(&mockLIDStore{}, cs)
+	name := resolveContactName(client, phonePN, testLogger())
+	if name != "" {
+		t.Errorf("expected empty string, got %q", name)
+	}
+}
+
+// --- Tests for GetChatName contact resolution ---
+
+func TestGetChatName_NumericCachedName_ReResolved(t *testing.T) {
+	cs := &mockContactStore{contacts: map[types.JID]types.ContactInfo{
+		phonePN: {Found: true, FullName: "John Doe"},
+	}}
+	client := newTestClient(&mockLIDStore{}, cs)
+	ms := newTestMessageStore(t)
+	logger := testLogger()
+
+	// Pre-populate with numeric name (phone number)
+	_ = ms.StoreChat(phonePN.String(), "11234567890", time.Now())
+
+	name := GetChatName(client, ms, phonePN, phonePN.String(), nil, "", "", logger)
+	if name != "John Doe" {
+		t.Errorf("expected re-resolved name 'John Doe', got %q", name)
+	}
+}
+
+func TestGetChatName_NonNumericCachedName_Kept(t *testing.T) {
+	cs := &mockContactStore{contacts: map[types.JID]types.ContactInfo{
+		phonePN: {Found: true, FullName: "Jane Doe"},
+	}}
+	client := newTestClient(&mockLIDStore{}, cs)
+	ms := newTestMessageStore(t)
+	logger := testLogger()
+
+	_ = ms.StoreChat(phonePN.String(), "John Doe", time.Now())
+
+	name := GetChatName(client, ms, phonePN, phonePN.String(), nil, "", "", logger)
+	if name != "John Doe" {
+		t.Errorf("expected cached name 'John Doe', got %q", name)
+	}
+}
+
+func TestGetChatName_PushNameFallback(t *testing.T) {
+	cs := &mockContactStore{contacts: map[types.JID]types.ContactInfo{}}
+	client := newTestClient(&mockLIDStore{}, cs)
+	ms := newTestMessageStore(t)
+	logger := testLogger()
+
+	name := GetChatName(client, ms, phonePN, phonePN.String(), nil, "", "Dune", logger)
+	if name != "Dune" {
+		t.Errorf("expected 'Dune' from pushName, got %q", name)
+	}
+}
+
+// --- Integration test: handleMessage with PushName for LID contact ---
+
+func TestHandleMessage_PushNameUsedForLIDContact(t *testing.T) {
+	cs := &mockContactStore{contacts: map[types.JID]types.ContactInfo{}}
+	client := newTestClient(&mockLIDStore{}, cs)
+	ms := newTestMessageStore(t)
+	logger := testLogger()
+
+	msg := buildTextMessage(
+		phoneLID,
+		phoneLID,
+		phonePN,
+		types.EmptyJID,
+		false,
+		"Hello",
+	)
+	msg.Info.PushName = "Dune"
+
+	handleMessage(client, ms, msg, logger)
+
+	name, found := queryChat(ms, phonePN.String())
+	if !found {
+		t.Fatal("expected chat to exist")
+	}
+	if name != "Dune" {
+		t.Errorf("expected chat name 'Dune' from PushName, got %q", name)
 	}
 }


### PR DESCRIPTION
## Summary

Two improvements to the WhatsApp bridge:

### 1. Fix contact name resolution
- **Bug**: individual contacts displayed as phone numbers instead of names
- **Root cause**: `GetChatName()` only tried `FullName` from the contact store, skipping `PushName` and `BusinessName`. Cached numeric names were never re-resolved. The PushName fallback compared against the wrong JID for LID-resolved chats.
- **Fix**:
  - Add `resolveContactName()` with full fallback chain: FullName → PushName → BusinessName
  - Re-resolve cached names that are purely numeric
  - Pass PushName into `GetChatName()` (only for incoming messages — outgoing PushName is the sender's own name)
  - Remove buggy external PushName fallback block

### 2. Make HTTP bind address configurable
- Default bind changed from `0.0.0.0` to `127.0.0.1` (the bridge exposes private WhatsApp messages)
- New `WHATSAPP_BRIDGE_HOST` env var, consistent with existing `WHATSAPP_BRIDGE_PORT`
- Input validated with `net.ParseIP()`, address formatted with `net.JoinHostPort()` for IPv6 support

## Test plan
- `go test ./...` — 15/15 pass (7 existing + 8 new)
- New tests: resolveContactName (FullName, PushName, BusinessName, not found), GetChatName (numeric cache re-resolution, non-numeric cache kept, pushName fallback), handleMessage with PushName for LID contact
- No regressions on group chat names
- Bind address: default `127.0.0.1`, override with `WHATSAPP_BRIDGE_HOST=0.0.0.0`