### PR TITLE
feat(bridge): capture incoming WhatsApp call events

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A Model Context Protocol (MCP) server for WhatsApp, enabling Claude to read and 
 - **Contact Search**: Search contacts by name or phone number with `sender_display` format ("Name (phone)")
 - **Send Messages**: Send text messages to individuals or groups
 - **Media Support**: Send and download images, videos, documents, and voice messages
+- **Call History**: Capture incoming voice/video calls into a local SQLite table (live, 1:1 and group)
 - **Webhook Integration**: Forward incoming messages to external services
 - **Local Storage**: All messages stored locally in SQLite - only sent to Claude when you allow it
 
@@ -237,6 +238,49 @@ Copy `.env.example` to `.env` and configure as needed:
 | `WHATSAPP_DB_PATH` | `../whatsapp-bridge/store/messages.db` | Path to SQLite database |
 | `WHATSMEOW_DB_PATH` | `../whatsapp-bridge/store/whatsapp.db` | whatsmeow DB used for LID ↔ phone resolution |
 | `WHATSAPP_API_URL` | `http://localhost:8080/api` | Go bridge REST API URL |
+
+## Call History
+
+The bridge captures incoming WhatsApp voice and video calls live into a
+dedicated `calls` table in `messages.db`. When a 1:1 call arrives
+(`CallOffer`) or a group call is announced (`CallOfferNotice`), a row is
+inserted with `result='in_progress'`. Subsequent `CallAccept` /
+`CallReject` / `CallTerminate` events update the row — final result becomes
+`answered`, `rejected`, `missed`, or `ended` depending on the event
+sequence. See the state-machine comment above `StoreCallOffer` in `main.go`
+for the exact transitions.
+
+### Schema
+
+```sql
+CREATE TABLE calls (
+    call_id TEXT,
+    chat_jid TEXT,          -- group JID for group calls, call creator JID for 1:1
+    from_jid TEXT,          -- JID of whoever started the call
+    timestamp TIMESTAMP,    -- call start time
+    is_from_me BOOLEAN,
+    call_type TEXT,         -- 'voice' or 'video'
+    is_group BOOLEAN,
+    result TEXT,            -- 'in_progress' | 'answered' | 'ended' |
+                            --   'missed' | 'rejected'
+    duration_sec INTEGER,   -- computed when the call terminates
+    ended_at TIMESTAMP,
+    reason TEXT,            -- terminate reason string from whatsmeow
+    PRIMARY KEY (call_id, chat_jid)
+);
+```
+
+### Caveats
+
+- **Outbound calls are not captured.** WhatsApp's primary device handles
+  calls it initiates without notifying linked devices, so the bridge never
+  sees an event for them.
+- **Call results only reflect what the bridge saw.** If the bridge is
+  offline when a call happens, the events are lost.
+- **1:1 calls default to `call_type='voice'`.** `CallOffer` events don't
+  expose media type directly (it's buried in the binary call data). Group
+  calls via `CallOfferNotice` include a `Media` field and are recorded
+  accurately as voice or video.
 
 ## Architecture
 

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -106,6 +106,24 @@ func NewMessageStore() (*MessageStore, error) {
 			PRIMARY KEY (id, chat_jid),
 			FOREIGN KEY (chat_jid) REFERENCES chats(jid)
 		);
+
+		CREATE TABLE IF NOT EXISTS calls (
+			call_id TEXT,
+			chat_jid TEXT,
+			from_jid TEXT,
+			timestamp TIMESTAMP,
+			is_from_me BOOLEAN,
+			call_type TEXT,
+			is_group BOOLEAN,
+			result TEXT,
+			duration_sec INTEGER,
+			ended_at TIMESTAMP,
+			reason TEXT,
+			PRIMARY KEY (call_id, chat_jid)
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_calls_chat ON calls(chat_jid);
+		CREATE INDEX IF NOT EXISTS idx_calls_timestamp ON calls(timestamp);
 	`)
 	if err != nil {
 		_ = db.Close()
@@ -401,6 +419,74 @@ func (store *MessageStore) GetMessages(chatJID string, limit int) ([]Message, er
 	}
 
 	return messages, nil
+}
+
+// Call storage methods.
+//
+// WhatsApp calls arrive as a sequence of events: Offer/OfferNotice → Accept →
+// Terminate (or Reject → Terminate). We model each call as a single row keyed
+// by (call_id, chat_jid), upserted as events arrive. The `result` column
+// tracks the call's final state as the event sequence plays out.
+//
+// State machine:
+//   Offer/OfferNotice → result = "in_progress"
+//   Accept            → result = "answered"
+//   Reject            → result = "rejected"
+//   Terminate         → if result == "in_progress" → "missed"
+//                       if result == "answered"    → "ended"
+//                       otherwise preserve existing (rejected stays rejected)
+
+// StoreCallOffer inserts a new call row when an offer event arrives. Uses
+// INSERT OR IGNORE so duplicate offer events (rare but possible) don't clobber
+// a call already in a later lifecycle state.
+func (store *MessageStore) StoreCallOffer(callID, chatJID, fromJID string, timestamp time.Time, isFromMe bool, callType string, isGroup bool) error {
+	_, err := store.db.Exec(
+		`INSERT OR IGNORE INTO calls
+		 (call_id, chat_jid, from_jid, timestamp, is_from_me, call_type, is_group, result)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, 'in_progress')`,
+		callID, chatJID, fromJID, timestamp, isFromMe, callType, isGroup,
+	)
+	return err
+}
+
+// MarkCallAnswered records that the offer was accepted.
+func (store *MessageStore) MarkCallAnswered(callID, chatJID string) error {
+	_, err := store.db.Exec(
+		`UPDATE calls SET result = 'answered'
+		 WHERE call_id = ? AND chat_jid = ? AND result = 'in_progress'`,
+		callID, chatJID,
+	)
+	return err
+}
+
+// MarkCallRejected records that the call was explicitly rejected.
+func (store *MessageStore) MarkCallRejected(callID, chatJID string) error {
+	_, err := store.db.Exec(
+		`UPDATE calls SET result = 'rejected'
+		 WHERE call_id = ? AND chat_jid = ? AND result = 'in_progress'`,
+		callID, chatJID,
+	)
+	return err
+}
+
+// MarkCallTerminated records the end of a call, computing duration from the
+// offer timestamp. Infers final result when the call was still in_progress
+// (meaning no accept was seen → the call was missed).
+func (store *MessageStore) MarkCallTerminated(callID, chatJID, reason string, endedAt time.Time) error {
+	_, err := store.db.Exec(
+		`UPDATE calls SET
+			ended_at = ?,
+			duration_sec = CAST((julianday(?) - julianday(timestamp)) * 86400 AS INTEGER),
+			reason = ?,
+			result = CASE result
+				WHEN 'in_progress' THEN 'missed'
+				WHEN 'answered'    THEN 'ended'
+				ELSE result
+			END
+		 WHERE call_id = ? AND chat_jid = ?`,
+		endedAt, endedAt, reason, callID, chatJID,
+	)
+	return err
 }
 
 // Get all chats
@@ -1443,6 +1529,44 @@ func main() {
 			// Process history sync events
 			handleHistorySync(client, messageStore, v, logger)
 
+		case *events.CallOffer:
+			// 1:1 incoming call. call_type defaults to "voice"; CallOffer
+			// doesn't expose Media directly (it's buried in the binary Data
+			// node). Group calls come through CallOfferNotice instead, which
+			// DOES expose Media cleanly.
+			handleCallOffer(client, messageStore, v.BasicCallMeta, "voice", false, logger)
+
+		case *events.CallOfferNotice:
+			// Group calls. v.Media is "audio" or "video"; normalize to our
+			// "voice"/"video" convention.
+			callType := "voice"
+			if v.Media == "video" {
+				callType = "video"
+			}
+			isGroup := v.Type == "group" || !v.BasicCallMeta.GroupJID.IsEmpty()
+			handleCallOffer(client, messageStore, v.BasicCallMeta, callType, isGroup, logger)
+
+		case *events.CallAccept:
+			if err := messageStore.MarkCallAnswered(v.CallID, callChatJID(v.BasicCallMeta)); err != nil {
+				logger.Warnf("Failed to mark call answered: %v", err)
+			} else {
+				logger.Infof("Call answered: id=%s", v.CallID)
+			}
+
+		case *events.CallReject:
+			if err := messageStore.MarkCallRejected(v.CallID, callChatJID(v.BasicCallMeta)); err != nil {
+				logger.Warnf("Failed to mark call rejected: %v", err)
+			} else {
+				logger.Infof("Call rejected: id=%s", v.CallID)
+			}
+
+		case *events.CallTerminate:
+			if err := messageStore.MarkCallTerminated(v.CallID, callChatJID(v.BasicCallMeta), v.Reason, v.Timestamp); err != nil {
+				logger.Warnf("Failed to mark call terminated: %v", err)
+			} else {
+				logger.Infof("Call terminated: id=%s reason=%q", v.CallID, v.Reason)
+			}
+
 		case *events.Connected:
 			logger.Infof("✓ Successfully connected to WhatsApp servers")
 
@@ -1743,9 +1867,72 @@ func GetChatName(client *whatsmeow.Client, messageStore *MessageStore, jid types
 	return name
 }
 
-// Handle history sync events
+// callChatJID resolves the chat JID that a call belongs to. For group calls
+// this is the group JID; for 1:1 calls it's the call creator's JID — which
+// stays stable across the entire lifecycle (Offer → Accept → Terminate).
+//
+// meta.From is NOT reliable as the chat key: for Accept events that fire
+// when the user picks up on their phone, meta.From is the *accepting*
+// device's JID (our own), not the other party's. Using From caused Accept
+// UPDATEs to miss the row stored at Offer time, so the state machine fell
+// through to "missed" when the user answered elsewhere.
+//
+// meta.CallCreator is populated from the stanza's call-creator attribute,
+// which WhatsApp keeps consistent for every event in the call.
+func callChatJID(meta types.BasicCallMeta) string {
+	if !meta.GroupJID.IsEmpty() {
+		return meta.GroupJID.String()
+	}
+	if !meta.CallCreator.IsEmpty() {
+		return meta.CallCreator.ToNonAD().String()
+	}
+	return meta.From.ToNonAD().String()
+}
+
+// handleCallOffer stores a new call row. The isFromMe path is defensive —
+// in practice WhatsApp's primary device handles outbound calls without
+// notifying linked devices, so events observed here are always inbound and
+// isFromMe stays false. We keep the branch anyway in case behavior changes.
+func handleCallOffer(client *whatsmeow.Client, messageStore *MessageStore, meta types.BasicCallMeta, callType string, isGroup bool, logger waLog.Logger) {
+	chatJID := callChatJID(meta)
+
+	fromJID := ""
+	switch {
+	case !meta.CallCreator.IsEmpty():
+		fromJID = meta.CallCreator.ToNonAD().String()
+	case !meta.From.IsEmpty():
+		fromJID = meta.From.ToNonAD().String()
+	}
+
+	isFromMe := client.Store.ID != nil && fromJID == client.Store.ID.ToNonAD().String()
+
+	if err := messageStore.StoreCallOffer(meta.CallID, chatJID, fromJID, meta.Timestamp, isFromMe, callType, isGroup); err != nil {
+		logger.Warnf("Failed to store call offer: %v", err)
+		return
+	}
+
+	kind := "Call"
+	if isGroup {
+		kind = "Group call"
+	}
+	direction := "incoming"
+	if isFromMe {
+		direction = "outgoing"
+	}
+	logger.Infof("%s %s: id=%s type=%s from=%s chat=%s",
+		kind, direction, meta.CallID, callType, fromJID, chatJID)
+}
+
 func handleHistorySync(client *whatsmeow.Client, messageStore *MessageStore, historySync *events.HistorySync, logger waLog.Logger) {
-	fmt.Printf("Received history sync event with %d conversations\n", len(historySync.Data.Conversations))
+	// Log every history sync event with its shape. Different sync types
+	// carry different payloads; logging type/chunk/progress makes it easy
+	// to reason about what arrived from WhatsApp when debugging.
+	logger.Infof("Received history sync: type=%s chunk=%d progress=%d conversations=%d",
+		historySync.Data.GetSyncType(),
+		historySync.Data.GetChunkOrder(),
+		historySync.Data.GetProgress(),
+		len(historySync.Data.Conversations),
+	)
 
 	syncedCount := 0
 	for _, conversation := range historySync.Data.Conversations {

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -473,10 +473,12 @@ func (store *MessageStore) MarkCallRejected(callID, chatJID string) error {
 // offer timestamp. Infers final result when the call was still in_progress
 // (meaning no accept was seen → the call was missed).
 func (store *MessageStore) MarkCallTerminated(callID, chatJID, reason string, endedAt time.Time) error {
+	// ROUND before CAST: julianday() arithmetic produces a float and CAST truncates
+	// toward zero, so a 90-second call would otherwise record as 89.
 	_, err := store.db.Exec(
 		`UPDATE calls SET
 			ended_at = ?,
-			duration_sec = CAST((julianday(?) - julianday(timestamp)) * 86400 AS INTEGER),
+			duration_sec = CAST(ROUND((julianday(?) - julianday(timestamp)) * 86400) AS INTEGER),
 			reason = ?,
 			result = CASE result
 				WHEN 'in_progress' THEN 'missed'

--- a/whatsapp-bridge/main_test.go
+++ b/whatsapp-bridge/main_test.go
@@ -75,6 +75,20 @@ func newTestMessageStore(t *testing.T) *MessageStore {
 			PRIMARY KEY (id, chat_jid),
 			FOREIGN KEY (chat_jid) REFERENCES chats(jid)
 		);
+		CREATE TABLE calls (
+			call_id TEXT,
+			chat_jid TEXT,
+			from_jid TEXT,
+			timestamp TIMESTAMP,
+			is_from_me BOOLEAN,
+			call_type TEXT,
+			is_group BOOLEAN,
+			result TEXT,
+			duration_sec INTEGER,
+			ended_at TIMESTAMP,
+			reason TEXT,
+			PRIMARY KEY (call_id, chat_jid)
+		);
 	`)
 	if err != nil {
 		t.Fatalf("failed to create tables: %v", err)
@@ -574,5 +588,226 @@ func TestHandleMessage_ImageWithCaption_WebhookForwarded(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for webhook call")
+	}
+}
+
+// queryCallResult returns the (result, duration_sec, reason) for a call row,
+// or empties if no row exists.
+func queryCallResult(ms *MessageStore, callID, chatJID string) (result string, duration sql.NullInt64, reason sql.NullString, found bool) {
+	err := ms.db.QueryRow(
+		"SELECT result, duration_sec, reason FROM calls WHERE call_id = ? AND chat_jid = ?",
+		callID, chatJID,
+	).Scan(&result, &duration, &reason)
+	return result, duration, reason, err == nil
+}
+
+// TestCallStateMachine_AllTransitions exercises every documented transition of
+// the call lifecycle state machine and pins down the non-obvious invariants:
+//
+//   - Offer → Accept → Terminate          ⇒ "ended" (with computed duration)
+//   - Offer → Terminate (no Accept)       ⇒ "missed"
+//   - Offer → Reject → Terminate          ⇒ "rejected" is preserved
+//     (Terminate's CASE branch must NOT downgrade rejected to ended/missed)
+//   - Duplicate Offer events do not clobber a call already in a later state
+//   - MarkCallAnswered/Rejected only fire when row is still in_progress
+func TestCallStateMachine_AllTransitions(t *testing.T) {
+	type step struct {
+		name string
+		do   func(ms *MessageStore) error
+	}
+
+	t0 := time.Date(2026, 4, 22, 10, 0, 0, 0, time.UTC)
+	t30 := t0.Add(30 * time.Second)
+	t90 := t0.Add(90 * time.Second)
+
+	cases := []struct {
+		name         string
+		callID       string
+		chatJID      string
+		steps        []step
+		wantResult   string
+		wantDuration int64 // 0 = expect NULL
+		wantReason   string
+	}{
+		{
+			name:    "Offer→Accept→Terminate yields ended with duration",
+			callID:  "call-answered",
+			chatJID: "creator@s.whatsapp.net",
+			steps: []step{
+				{"offer", func(ms *MessageStore) error {
+					return ms.StoreCallOffer("call-answered", "creator@s.whatsapp.net", "creator@s.whatsapp.net", t0, false, "voice", false)
+				}},
+				{"accept", func(ms *MessageStore) error {
+					return ms.MarkCallAnswered("call-answered", "creator@s.whatsapp.net")
+				}},
+				{"terminate", func(ms *MessageStore) error {
+					return ms.MarkCallTerminated("call-answered", "creator@s.whatsapp.net", "normal", t90)
+				}},
+			},
+			wantResult:   "ended",
+			wantDuration: 90,
+			wantReason:   "normal",
+		},
+		{
+			name:    "Offer→Terminate with no Accept yields missed",
+			callID:  "call-missed",
+			chatJID: "creator@s.whatsapp.net",
+			steps: []step{
+				{"offer", func(ms *MessageStore) error {
+					return ms.StoreCallOffer("call-missed", "creator@s.whatsapp.net", "creator@s.whatsapp.net", t0, false, "voice", false)
+				}},
+				{"terminate", func(ms *MessageStore) error {
+					return ms.MarkCallTerminated("call-missed", "creator@s.whatsapp.net", "timeout", t30)
+				}},
+			},
+			wantResult:   "missed",
+			wantDuration: 30,
+			wantReason:   "timeout",
+		},
+		{
+			name:    "Offer→Reject→Terminate preserves rejected",
+			callID:  "call-rejected",
+			chatJID: "creator@s.whatsapp.net",
+			steps: []step{
+				{"offer", func(ms *MessageStore) error {
+					return ms.StoreCallOffer("call-rejected", "creator@s.whatsapp.net", "creator@s.whatsapp.net", t0, false, "voice", false)
+				}},
+				{"reject", func(ms *MessageStore) error {
+					return ms.MarkCallRejected("call-rejected", "creator@s.whatsapp.net")
+				}},
+				{"terminate", func(ms *MessageStore) error {
+					return ms.MarkCallTerminated("call-rejected", "creator@s.whatsapp.net", "rejected_by_user", t30)
+				}},
+			},
+			wantResult:   "rejected",
+			wantDuration: 30,
+			wantReason:   "rejected_by_user",
+		},
+		{
+			name:    "Duplicate Offer does not clobber later state",
+			callID:  "call-dup-offer",
+			chatJID: "creator@s.whatsapp.net",
+			steps: []step{
+				{"offer", func(ms *MessageStore) error {
+					return ms.StoreCallOffer("call-dup-offer", "creator@s.whatsapp.net", "creator@s.whatsapp.net", t0, false, "voice", false)
+				}},
+				{"accept", func(ms *MessageStore) error {
+					return ms.MarkCallAnswered("call-dup-offer", "creator@s.whatsapp.net")
+				}},
+				{"duplicate offer (should be ignored)", func(ms *MessageStore) error {
+					return ms.StoreCallOffer("call-dup-offer", "creator@s.whatsapp.net", "creator@s.whatsapp.net", t0, false, "voice", false)
+				}},
+				{"terminate", func(ms *MessageStore) error {
+					return ms.MarkCallTerminated("call-dup-offer", "creator@s.whatsapp.net", "normal", t90)
+				}},
+			},
+			wantResult:   "ended",
+			wantDuration: 90,
+			wantReason:   "normal",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ms := newTestMessageStore(t)
+			for _, s := range tc.steps {
+				if err := s.do(ms); err != nil {
+					t.Fatalf("step %q failed: %v", s.name, err)
+				}
+			}
+
+			result, duration, reason, found := queryCallResult(ms, tc.callID, tc.chatJID)
+			if !found {
+				t.Fatalf("expected row for call_id=%s chat_jid=%s, got none", tc.callID, tc.chatJID)
+			}
+			if result != tc.wantResult {
+				t.Errorf("result: got %q, want %q", result, tc.wantResult)
+			}
+			if !duration.Valid || duration.Int64 != tc.wantDuration {
+				t.Errorf("duration_sec: got %v, want %d", duration, tc.wantDuration)
+			}
+			if !reason.Valid || reason.String != tc.wantReason {
+				t.Errorf("reason: got %v, want %q", reason, tc.wantReason)
+			}
+		})
+	}
+}
+
+// TestCallStateMachine_AcceptAndRejectAreNoOpAfterTerminate verifies that
+// late-arriving Accept/Reject events (post-Terminate) do not corrupt a
+// finalized row. The WHERE result='in_progress' guard is what enforces this.
+func TestCallStateMachine_AcceptAndRejectAreNoOpAfterTerminate(t *testing.T) {
+	ms := newTestMessageStore(t)
+	t0 := time.Date(2026, 4, 22, 10, 0, 0, 0, time.UTC)
+
+	if err := ms.StoreCallOffer("call-late", "creator@s.whatsapp.net", "creator@s.whatsapp.net", t0, false, "voice", false); err != nil {
+		t.Fatalf("offer: %v", err)
+	}
+	if err := ms.MarkCallTerminated("call-late", "creator@s.whatsapp.net", "timeout", t0.Add(30*time.Second)); err != nil {
+		t.Fatalf("terminate: %v", err)
+	}
+
+	// These should be no-ops because the row is already 'missed', not 'in_progress'.
+	_ = ms.MarkCallAnswered("call-late", "creator@s.whatsapp.net")
+	_ = ms.MarkCallRejected("call-late", "creator@s.whatsapp.net")
+
+	result, _, _, _ := queryCallResult(ms, "call-late", "creator@s.whatsapp.net")
+	if result != "missed" {
+		t.Errorf("expected missed to be preserved, got %q", result)
+	}
+}
+
+// TestCallChatJID_Precedence pins down the precedence rules in callChatJID:
+//
+//  1. GroupJID wins (group calls always key on the group)
+//  2. CallCreator wins over From (the bug Ed fixed: Accept events arrive
+//     with From=accepter's JID, which is "us" if user picked up on phone)
+//  3. From is the last-resort fallback
+//
+// Without rule 2, Accept UPDATEs miss the row stored at Offer time and the
+// state machine falls through to "missed" when the user answered elsewhere.
+func TestCallChatJID_Precedence(t *testing.T) {
+	groupJID := types.JID{User: "120363012345678901", Server: types.GroupServer}
+	creatorJID := types.JID{User: "11234567890", Server: types.DefaultUserServer}
+	fromJID := types.JID{User: "19998887777", Server: types.DefaultUserServer}
+
+	cases := []struct {
+		name string
+		meta types.BasicCallMeta
+		want string
+	}{
+		{
+			name: "group JID wins when present",
+			meta: types.BasicCallMeta{
+				GroupJID:    groupJID,
+				CallCreator: creatorJID,
+				From:        fromJID,
+			},
+			want: groupJID.String(),
+		},
+		{
+			name: "creator wins over From for 1:1 (Accept-from-other-device case)",
+			meta: types.BasicCallMeta{
+				CallCreator: creatorJID,
+				From:        fromJID,
+			},
+			want: creatorJID.ToNonAD().String(),
+		},
+		{
+			name: "From is fallback when creator is empty",
+			meta: types.BasicCallMeta{
+				From: fromJID,
+			},
+			want: fromJID.ToNonAD().String(),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := callChatJID(tc.meta)
+			if got != tc.want {
+				t.Errorf("callChatJID() = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #38.

Adds a `calls` table and event handlers for WhatsApp voice/video call lifecycle events. Each call becomes one row keyed by `(call_id, chat_jid)`, upserted as events arrive:

```
Offer / OfferNotice  → INSERT with result='in_progress'
Accept               → UPDATE result='answered'
Reject               → UPDATE result='rejected'
Terminate            → UPDATE ended_at, duration_sec;
                       result becomes 'missed' (if was in_progress)
                       or 'ended' (if was answered); preserves 'rejected'
```

## What's captured

| column | notes |
|---|---|
| `call_id` | WhatsApp's call identifier, unique per call |
| `chat_jid` | group JID for groups, call-creator JID for 1:1. Stable across lifecycle — **keyed on `meta.CallCreator`, not `meta.From`**, because Accept events fire with `From=accepter's JID` when user picks up on another device |
| `from_jid` | whoever initiated the call |
| `is_from_me` | defensive; in practice always false because outbound calls aren't sent to linked devices |
| `call_type` | `voice`/`video`. Group calls get accurate media from `CallOfferNotice.Media`; 1:1 defaults to voice (`CallOffer` doesn't expose media directly) |
| `is_group` | whether it's a group call |
| `result` | `in_progress` → `answered` → `ended`, or `missed` / `rejected` |
| `duration_sec`, `ended_at`, `reason` | populated on terminate |

Plus: informational log line at the start of `handleHistorySync` showing sync `type`, `chunk`, `progress`, and conversation count — useful for debugging sync behavior.

## Testing

Verified end-to-end with live incoming 1:1 calls on iOS WhatsApp 2.26.x, 2026-04-18:

- `CallOffer` → row inserted with `result='in_progress'`
- `CallAccept` → `result='answered'`
- `CallTerminate` with `reason=accepted_elsewhere` (user answered on phone) → `result='ended'`, `duration_sec` computed

State machine also handles:
- Call rejected on bridge or remotely → `result='rejected'` (Reject UPDATE runs, then Terminate preserves `rejected` via the CASE branch)
- Missed call (Offer → Terminate with no Accept) → `result='missed'`

## Known limitations (documented in README)

- **Outbound calls are not captured.** WhatsApp's primary device handles outgoing calls without notifying linked devices, so no events arrive for them.
- **1:1 calls default to `call_type='voice'`.** `CallOffer` doesn't expose media type directly; it's buried in the binary `Data` node. Group calls via `CallOfferNotice` are accurate.
- **Bridge-offline gaps.** If the bridge is down when a call happens, the events are lost (no retry mechanism in whatsmeow).

## Changes

- `whatsapp-bridge/main.go`: +190 lines (schema, 4 MessageStore methods, 5 event handler cases, `callChatJID` + `handleCallOffer` helpers, diagnostic log line in `handleHistorySync`)
- `README.md`: +44 lines (Features bullet + Call History section with schema + caveats)

No new dependencies.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean
- [x] Live incoming 1:1 call → row inserted, state transitions correctly
- [x] Call answered on a different device (`accepted_elsewhere`) → result correctly lands on `ended`, not `missed`
- [x] `CREATE TABLE IF NOT EXISTS` safe on existing messages.db — verified locally by applying to a DB with 52k existing message rows
- [x] PK `(call_id, chat_jid)` prevents duplicates on reconnect-replay

## Out of scope

- **Historical call backfill from `HistorySync.CallLogRecords`.** Initially implemented and tested; in measurement against iOS WhatsApp 2.26.x with `--full-history-pair` (PR #37), the phone delivered 0 call records across all 11 FULL sync chunks. `grep`ping whatsmeow shows zero code referencing `CallLogRecords`, suggesting WhatsApp may have moved call-log sync to a different mechanism that isn't via the `HistorySync` proto. Code was removed from this PR to avoid shipping speculative dead paths — happy to revisit if someone has a working counter-example.
- **Python MCP tool for querying `calls`.** Follow-up if desired; the table is queryable from MCP via ATTACH like `transcriptions.db` already is.