### PR TITLE
ci: bump Go toolchain to 1.25 across workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
       - name: Build
         run: |
           cd whatsapp-bridge

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
 
       - uses: actions/setup-python@v6
         with:
@@ -68,7 +68,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
 
       - uses: astral-sh/setup-uv@v7
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
@@ -99,7 +99,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest


### PR DESCRIPTION
## Summary

`govulncheck@latest` now requires Go ≥ 1.25 (`golang.org/x/vuln@v1.2.0`), which broke the **Security** workflow on every open PR with:

```
golang.org/x/vuln@v1.2.0 requires go >= 1.25.0
(running go 1.24.13; GOTOOLCHAIN=local)
```

This bumps `setup-go` to `1.25` in every workflow for consistency:

- `ci.yml` — `go-lint`, `go-build`
- `security.yml` — `codeql-go`, `govulncheck`
- `release.yml` — validate + publish jobs
- `release-please.yml` — publish-release-assets

## Why now

Unblocks the entire dependabot queue (#17, #18, #19, #31, #32, #33, #34, #35) and gives every other open PR a clean CI signal again.

## Test plan

- [ ] CI runs green on this PR (especially `Go Vulnerability Check`)
- [ ] Re-run any open PR after merge — expect green checks