### PR TITLE
docs: update remaining "go run main.go" references to "go run ."

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -23,7 +23,7 @@ body:
       label: Steps to reproduce
       description: Exact, minimal steps. Include commands, tool calls, or curl invocations.
       placeholder: |
-        1. Start the bridge: `go run main.go`
+        1. Start the bridge: `go run .`
         2. From Claude Desktop, call `send_message` with `{...}`
         3. Observe ...
     validations:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ If unsure whether something is in scope, **open an issue first**. Do not open a 
 ```bash
 # Go bridge
 cd whatsapp-bridge
-go run main.go              # dev
+go run .                    # dev
 go build -o whatsapp-bridge && ./whatsapp-bridge   # release-ish
 golangci-lint run           # lint
 go test ./...               # tests (sparse today)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ cd whatsapp-mcp
 
 # Bridge
 cd whatsapp-bridge
-go run main.go     # scan QR to pair
+go run .           # scan QR to pair
 
 # MCP server (separate terminal)
 cd ../whatsapp-mcp-server

--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ Windows requires CGO for go-sqlite3. Install [MSYS2](https://www.msys2.org/) and
 
 ```bash
 go env -w CGO_ENABLED=1
-go run main.go
+go run .
 ```
 
 ## Security Notice


### PR DESCRIPTION
## Summary

Follow-up to #23 — same fix, remaining references.

After `webhook.go` was added as a separate file in the bridge package, `go run main.go` fails with `undefined: SendWebhook` because Go only compiles the file you name. `go run .` compiles all `.go` files in the package.

#23 fixed the primary install instruction in `README.md`. This PR cleans up four remaining references:

- `README.md` — Windows / CGO section
- `AGENTS.md` — Local commands
- `CONTRIBUTING.md` — Setup
- `.github/ISSUE_TEMPLATE/bug_report.yml` — example reproduction step

## Test plan

- [x] No `go run main.go` left anywhere: `rg 'go run main\.go'` → no matches.

Refs #22.