### PR TITLE
docs: document WHATSMEOW_DB_PATH env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,5 +19,9 @@ FORWARD_SELF=false
 # Default: relative path to whatsapp-bridge/store/messages.db
 WHATSAPP_DB_PATH=./whatsapp-bridge/store/messages.db
 
+# Path to whatsmeow's SQLite database (used to resolve LIDs ↔ phone numbers)
+# Default: relative path to whatsapp-bridge/store/whatsapp.db
+WHATSMEOW_DB_PATH=./whatsapp-bridge/store/whatsapp.db
+
 # Go bridge REST API URL
 WHATSAPP_API_URL=http://localhost:8080/api

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,7 @@ A failing blocking job is a hard block — fix it or explain in the PR why it's 
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `WHATSAPP_DB_PATH` | `../whatsapp-bridge/store/messages.db` | SQLite path used by the MCP server |
+| `WHATSMEOW_DB_PATH` | `../whatsapp-bridge/store/whatsapp.db` | whatsmeow SQLite (LID ↔ phone resolution via `whatsmeow_lid_map`) |
 | `WHATSAPP_API_URL` | `http://localhost:8080/api` | Bridge REST endpoint |
 | `WHATSAPP_BRIDGE_PORT` | `8080` | Port the bridge binds to |
 | `WEBHOOK_URL` | `http://localhost:8769/whatsapp/webhook` | Outgoing webhook for incoming messages (empty = disabled) |

--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ Copy `.env.example` to `.env` and configure as needed:
 | `WEBHOOK_URL` | `http://localhost:8769/whatsapp/webhook` | Webhook for incoming messages |
 | `FORWARD_SELF` | `false` | Forward messages sent by self |
 | `WHATSAPP_DB_PATH` | `../whatsapp-bridge/store/messages.db` | Path to SQLite database |
+| `WHATSMEOW_DB_PATH` | `../whatsapp-bridge/store/whatsapp.db` | whatsmeow DB used for LID ↔ phone resolution |
 | `WHATSAPP_API_URL` | `http://localhost:8080/api` | Go bridge REST API URL |
 
 ## Architecture


### PR DESCRIPTION
Follow-up to #43.

Adds `WHATSMEOW_DB_PATH` to:
- `.env.example`
- `README.md` env var table
- `AGENTS.md` env var table

So users know they can override the path to whatsmeow's SQLite store (used by `_sender_aliases` for LID ↔ phone resolution).
