### PR TITLE
chore: add @edmenendez as codeowner for bridge + whatsapp.py

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,14 @@
 # Default — every PR
 *                               @jack-arturo
 
+# Go bridge — Ed has deep knowledge of whatsmeow internals (LIDs, history sync,
+# stream events, media handling). Auto-request his review on bridge changes.
+/whatsapp-bridge/               @jack-arturo @edmenendez
+
+# MCP server's whatsapp.py also touches whatsmeow's SQLite (LID resolution,
+# contact store) — same domain expertise applies.
+/whatsapp-mcp-server/whatsapp.py @jack-arturo @edmenendez
+
 # CI / release / governance — owner only
 /.github/                       @jack-arturo
 /release-please-config.json     @jack-arturo


### PR DESCRIPTION
Adds @edmenendez as a codeowner alongside @jack-arturo for:

- \`whatsapp-bridge/\` — Go bridge
- \`whatsapp-mcp-server/whatsapp.py\` — Python file that talks to whatsmeow's SQLite

## Why

Ed's been the most active contributor with deep whatsmeow expertise (LID/phone resolution, history sync, stream events, media handling). Auto-requesting his review on bridge changes will catch issues early and lighten the bottleneck on me.

Recently merged: #27, #30, #40, #41, #42, #43.

Also sent a \`Maintain\` collaborator invite — branch protection still gates \`main\`, so this just lets him merge approved PRs without me being the only bottleneck.