### PR TITLE
fix: security hardening for LAN exposure and Unicode search

### DIFF
--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -1447,8 +1447,9 @@ func startRESTServer(client *whatsmeow.Client, messageStore *MessageStore, port 
 		}
 	})
 
-	// Start the server with proper timeouts
-	serverAddr := fmt.Sprintf(":%d", port)
+	// Start the server with proper timeouts. Bind to loopback so the bridge is
+	// not reachable from the LAN; MCP clients talk to it over localhost.
+	serverAddr := fmt.Sprintf("127.0.0.1:%d", port)
 	fmt.Printf("Starting REST API server on %s...\n", serverAddr)
 
 	// Create server with timeouts for stability

--- a/whatsapp-mcp-server/whatsapp.py
+++ b/whatsapp-mcp-server/whatsapp.py
@@ -394,8 +394,12 @@ def list_messages(
             params.append(chat_jid)
 
         if query:
-            where_clauses.append("LOWER(messages.content) LIKE LOWER(?)")
-            params.append(f"%{query}%")
+            # SQLite's LOWER() only handles ASCII, so LIKE LOWER(...) silently
+            # excludes Unicode matches. instr() on the raw column preserves them.
+            where_clauses.append(
+                "(instr(LOWER(messages.content), LOWER(?)) > 0 OR instr(messages.content, ?) > 0)"
+            )
+            params.extend([query, query])
 
         if where_clauses:
             query_parts.append("WHERE " + " AND ".join(where_clauses))
@@ -593,8 +597,11 @@ def list_chats(
         params = []
 
         if query:
-            where_clauses.append("(LOWER(chats.name) LIKE LOWER(?) OR chats.jid LIKE ?)")
-            params.extend([f"%{query}%", f"%{query}%"])
+            # instr() on the raw column matches Unicode; LOWER()+LIKE only covers ASCII.
+            where_clauses.append(
+                "(instr(LOWER(chats.name), LOWER(?)) > 0 OR instr(chats.name, ?) > 0 OR chats.jid LIKE ?)"
+            )
+            params.extend([query, query, f"%{query}%"])
 
         if where_clauses:
             query_parts.append("WHERE " + " AND ".join(where_clauses))
@@ -641,7 +648,9 @@ def search_contacts(query: str) -> list[dict[str, Any]]:
     """
     seen_jids: set[str] = set()
     result: list[dict[str, Any]] = []
-    search_pattern = "%" + query + "%"
+    # JIDs are all ASCII so LIKE is safe; names use instr() because SQLite's
+    # LOWER() only folds case for ASCII and would drop Unicode matches.
+    jid_pattern = "%" + query + "%"
 
     # 1) Search messages.db chats table (existing behavior)
     try:
@@ -652,12 +661,12 @@ def search_contacts(query: str) -> list[dict[str, Any]]:
             SELECT DISTINCT jid, name
             FROM chats
             WHERE
-                (LOWER(name) LIKE LOWER(?) OR LOWER(jid) LIKE LOWER(?))
+                (instr(LOWER(name), LOWER(?)) > 0 OR instr(name, ?) > 0 OR jid LIKE ?)
                 AND jid NOT LIKE '%@g.us'
             ORDER BY name, jid
             LIMIT 50
         """,
-            (search_pattern, search_pattern),
+            (query, query, jid_pattern),
         )
         for jid, name in cursor.fetchall():
             if jid not in seen_jids:
@@ -680,14 +689,14 @@ def search_contacts(query: str) -> list[dict[str, Any]]:
                 SELECT their_jid, full_name, push_name, first_name, business_name
                 FROM whatsmeow_contacts
                 WHERE
-                    LOWER(full_name) LIKE LOWER(?)
-                    OR LOWER(push_name) LIKE LOWER(?)
-                    OR LOWER(first_name) LIKE LOWER(?)
-                    OR LOWER(business_name) LIKE LOWER(?)
+                    instr(LOWER(full_name), LOWER(?)) > 0 OR instr(full_name, ?) > 0
+                    OR instr(LOWER(push_name), LOWER(?)) > 0 OR instr(push_name, ?) > 0
+                    OR instr(LOWER(first_name), LOWER(?)) > 0 OR instr(first_name, ?) > 0
+                    OR instr(LOWER(business_name), LOWER(?)) > 0 OR instr(business_name, ?) > 0
                     OR their_jid LIKE ?
                 LIMIT 50
             """,
-                (search_pattern, search_pattern, search_pattern, search_pattern, search_pattern),
+                (query, query, query, query, query, query, query, query, jid_pattern),
             )
             for their_jid, full_name, push_name, first_name, business_name in cursor2.fetchall():
                 if their_jid not in seen_jids:

--- a/whatsapp-mcp-server/whatsapp.py
+++ b/whatsapp-mcp-server/whatsapp.py
@@ -396,9 +396,7 @@ def list_messages(
         if query:
             # SQLite's LOWER() only handles ASCII, so LIKE LOWER(...) silently
             # excludes Unicode matches. instr() on the raw column preserves them.
-            where_clauses.append(
-                "(instr(LOWER(messages.content), LOWER(?)) > 0 OR instr(messages.content, ?) > 0)"
-            )
+            where_clauses.append("(instr(LOWER(messages.content), LOWER(?)) > 0 OR instr(messages.content, ?) > 0)")
             params.extend([query, query])
 
         if where_clauses:


### PR DESCRIPTION
## Summary

Narrow, non-breaking security fixes cherry-picked from #28 for the 0.2.0 release. The full PR #28 bundles these with feature backports, a breaking RFC 3339 change, and a `whatsmeow` bump — those remain for the contributor to split (see `needs:split` on #28).

### Changes

- **SEC-1 — Bind Go bridge to 127.0.0.1** (`whatsapp-bridge/main.go`). The REST API previously listened on `0.0.0.0`, making the bridge reachable from any host on the local network. MCP clients run on the same machine, so scope the listener to loopback.
- **SEC-2 — Unicode-safe search via `instr()`** (`whatsapp-mcp-server/whatsapp.py`). SQLite's `LOWER()` only folds ASCII, and on some builds corrupts multi-byte UTF-8 through `LOWER() + LIKE`. Switched the text-match half of every search to `instr()`; JID columns stay on `LIKE` since JIDs are ASCII-only. Covers `list_messages`, `list_chats`, and **both** DB blocks in `search_contacts` (messages.db chats + whatsmeow_contacts — the latter was added after the contributor's branch was written, same bug pattern).

### Deliberately **not** included from #28 (deferred to split)

- SEC-3 — RFC 3339 timestamp enforcement on `after`/`before` filters (breaking)
- `format_timestamp_rfc3339_utc`, `parse_db_timestamp`, `parse_filter_timestamp` helpers
- `format_message` reformat (`[id:xxx]` suffix)
- `send_message` / `send_file` signature changes (`quoted_id`, `caption`)
- Go bridge features: explicit MIME types, `FileName` on documents, quoted-reply `ContextInfo`, `extractTextContent` for Interactive/Buttons/List messages, `filepath.Ext`/`Base` refactor
- `whatsmeow` + transitive dep bumps

## Test plan

- [x] `go build ./...` and `go test ./...` in `whatsapp-bridge` — pass
- [x] `pytest` in `whatsapp-mcp-server` — 12/12 pass
- [x] Confirmed restarted bridge binds to `127.0.0.1:8080` via `lsof` (was `*:8080`)
- [x] `curl http://127.0.0.1:8080/` responds; `curl http://<LAN-IP>:8080/` is refused
- [x] Probed SEC-2 against live 419-chat corpus (including 40 Unicode names — German umlauts, emoji, curly apostrophes) — zero regressions, identical result sets old vs new

## Notes

- Two `fix:` commits → Release Please will propose a patch bump. Add `Release-As: 0.2.0` to the release-please PR body if a minor is desired for today's cut.
- Cherry-picked rather than merged from #28 because the contributor's commit mixes all security + feature work in a single commit (not extractable as-is).

Closes nothing — leaves #28 open pending contributor split of the remaining work.