### PR TITLE
fix(ci): make dependabot auto-approve non-fatal

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -42,9 +42,5 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
-          CURRENT_LOGIN="$(gh api user --jq .login)"
-          ALREADY_APPROVED="$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" --jq '[.[] | select(.user.login == "'"$CURRENT_LOGIN"'" and .state == "APPROVED")] | length')"
-          if [ "$ALREADY_APPROVED" -eq 0 ]; then
-            gh pr review --approve "$PR_URL"
-          fi
+          gh pr review --approve "$PR_URL" 2>/dev/null || true
           gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
`gh pr review --approve` returns 403 for GITHUB_TOKEN when approving Dependabot PRs, which halts the step under bash -e and leaves auto-merge unset. Swallow the approval failure so `gh pr merge --auto --squash` still runs. Main isn't branch-protected, so approval isn't required for auto-merge to fire.