### PR TITLE
ci: skip code checks on docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,30 @@ on:
   workflow_dispatch:
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**'
+              - '!**/*.md'
+              - '!**/LICENSE'
+              - '!**/.gitignore'
+              - '!.github/ISSUE_TEMPLATE/**'
+              - '!.github/PULL_REQUEST_TEMPLATE.md'
+              - '!docs/**'
+
   version-consistency:
     name: Version Consistency
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -21,6 +43,8 @@ jobs:
 
   python-lint:
     name: Python Lint
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -41,6 +65,8 @@ jobs:
 
   go-lint:
     name: Go Lint
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -55,6 +81,8 @@ jobs:
 
   go-build:
     name: Go Build
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -68,6 +96,8 @@ jobs:
 
   python-test:
     name: Python Tests
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,8 +14,30 @@ permissions:
   security-events: write
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**'
+              - '!**/*.md'
+              - '!**/LICENSE'
+              - '!**/.gitignore'
+              - '!.github/ISSUE_TEMPLATE/**'
+              - '!.github/PULL_REQUEST_TEMPLATE.md'
+              - '!docs/**'
+
   codeql-python:
     name: CodeQL Analysis (Python)
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -33,6 +55,8 @@ jobs:
 
   codeql-go:
     name: CodeQL Analysis (Go)
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -54,6 +78,8 @@ jobs:
 
   python-audit:
     name: Python Dependency Audit
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -76,6 +102,8 @@ jobs:
 
   bandit:
     name: Bandit Security Scan
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -93,6 +121,8 @@ jobs:
 
   govulncheck:
     name: Go Vulnerability Check
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Stops running CodeQL, Bandit, ruff, golangci-lint, Go build, and pytest on PRs that touch only Markdown, LICENSE, or .gitignore. Triggered by #67 burning ~10 minutes of CI on a README-only update.

## How it works

- Adds a `changes` job using `dorny/paths-filter@v3` that exposes a `code` boolean.
- Each downstream job gates on `if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'`.
- Skipped jobs report as **passing** for required status checks (modern GitHub behavior), so the org-level required checks (`Python Lint`, `Python Tests`, `Go Lint`, `Go Build`) and repo-level required checks (`Version Consistency`, `CodeQL Analysis (Go)`, `CodeQL Analysis (Python)`, `Go Vulnerability Check`) stay green on docs-only PRs without blocking merge.
- Push to `main`, scheduled runs, and `workflow_dispatch` still execute the full suite via the `github.event_name != 'pull_request'` fallback.

## Excluded paths

```
**/*.md
**/LICENSE
**/.gitignore
.github/ISSUE_TEMPLATE/**
.github/PULL_REQUEST_TEMPLATE.md
docs/**
```

Anything else (including `.github/workflows/**` and `.github/scripts/**`) still triggers the full suite — intentional, so workflow changes get tested.

## Test plan

- [ ] Open a docs-only PR (or rebase #67 onto this) and confirm code jobs report as Skipped (green).
- [ ] Open a code PR and confirm full suite runs.
- [ ] Confirm push to `main` after merge runs everything.