### PR TITLE
ci: delegate Dependabot auto-merge to org reusable workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -10,4 +10,3 @@ permissions:
 jobs:
   auto-merge:
     uses: verygoodplugins/.github/.github/workflows/dependabot-auto-merge.yml@main
-    secrets: inherit

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
 
+permissions:
+  contents: write
+  pull-requests: write
 jobs:
   auto-merge:
     uses: verygoodplugins/.github/.github/workflows/dependabot-auto-merge.yml@main

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -9,4 +9,5 @@ permissions:
   pull-requests: write
 jobs:
   auto-merge:
+    if: github.actor == 'dependabot[bot]'
     uses: verygoodplugins/.github/.github/workflows/dependabot-auto-merge.yml@main

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,46 +1,10 @@
 name: Dependabot auto-merge
 
-# Auto-approves and enables auto-merge for low-risk Dependabot PRs:
-# - any patch update
-# - minor updates to development dependencies (pytest, ruff, etc.)
-# - minor updates to GitHub Actions
-#
-# Major updates and minor updates to runtime/production deps still
-# require manual review.
-
 on:
   pull_request_target:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
-
-permissions:
-  contents: write
-  pull-requests: write
+    types: [opened, reopened, synchronize, ready_for_review]
 
 jobs:
   auto-merge:
-    if: github.actor == 'dependabot[bot]'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Fetch Dependabot metadata
-        id: meta
-        uses: dependabot/fetch-metadata@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Approve and enable auto-merge
-        if: |
-          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
-          (steps.meta.outputs.update-type == 'version-update:semver-minor' &&
-           steps.meta.outputs.dependency-type == 'direct:development') ||
-          (steps.meta.outputs.update-type == 'version-update:semver-minor' &&
-           steps.meta.outputs.package-ecosystem == 'github_actions')
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-        run: |
-          gh pr review --approve "$PR_URL" 2>/dev/null || true
-          gh pr merge --auto --squash "$PR_URL"
+    uses: verygoodplugins/.github/.github/workflows/dependabot-auto-merge.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary

Replaces the inline auto-merge logic with a 6-line stub that calls the new reusable workflow at [`verygoodplugins/.github`](https://github.com/verygoodplugins/.github/blob/main/.github/workflows/dependabot-auto-merge.yml).

**Why:** Logic now lives in one place. Every other repo can adopt the same 6-line stub — no copy-paste drift.

**Expanded rules vs the old inline version:**

| Update type | Before | After |
|---|---|---|
| Patch (any dep) | ✅ auto | ✅ auto |
| Minor — dev dep | ✅ auto | ✅ auto |
| Minor/patch — Actions | ✅ auto | ✅ auto |
| **Indirect/transitive dep (any version)** | ❌ manual | ✅ auto |
| **Minor — direct runtime dep** | ❌ manual | ❌ manual (unchanged) |
| **Major — any dep** | ❌ manual | ❌ manual (unchanged) |

The `indirect` rule is the key addition — this is why PRs like #57 (starlette transitive bump / security fix) weren't auto-merging.

## Test plan

Merge this, then watch the 7 open Dependabot PRs (#57–#64). They should auto-approve and squash-merge once CI passes.