### PR TITLE
chore(security): defense-in-depth hardening

### DIFF
--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -1296,8 +1296,28 @@ func downloadMedia(client *whatsmeow.Client, messageStore *MessageStore, message
 	}
 	filename := fmt.Sprintf("%s_%s_%s%s", mediaType, timestamp.Format("20060102_150405"), messageID, ext)
 
-	// First, check if we already have this file
-	chatDir := fmt.Sprintf("store/%s", strings.ReplaceAll(chatJID, ":", "_"))
+	// Build the per-chat storage directory under store/.
+	//
+	// chatJID is normally produced by whatsmeow and well-formed, but it
+	// originates upstream from the WhatsApp protocol and ends up in a
+	// filesystem path here. We sanitize it defensively so a malformed or
+	// crafted JID can never escape the store/ directory via "../" or
+	// absolute-path components.
+	safeChatJID := strings.ReplaceAll(chatJID, ":", "_")
+	chatDir := filepath.Join("store", safeChatJID)
+	storeAbs, err := filepath.Abs("store")
+	if err != nil {
+		return false, "", "", "", fmt.Errorf("failed to resolve store path: %v", err)
+	}
+	chatDirAbs, err := filepath.Abs(chatDir)
+	if err != nil {
+		return false, "", "", "", fmt.Errorf("failed to resolve chat dir path: %v", err)
+	}
+	// Ensure the resolved chatDir is strictly inside store/ (defence in depth
+	// against future refactors or unexpected JID formats).
+	if chatDirAbs != storeAbs && !strings.HasPrefix(chatDirAbs, storeAbs+string(os.PathSeparator)) {
+		return false, "", "", "", fmt.Errorf("invalid chat JID: resolved path escapes store directory")
+	}
 
 	// Create directory for the chat if it doesn't exist
 	if err := os.MkdirAll(chatDir, 0755); err != nil {
@@ -1305,7 +1325,7 @@ func downloadMedia(client *whatsmeow.Client, messageStore *MessageStore, message
 	}
 
 	// Generate a local path for the file
-	localPath := fmt.Sprintf("%s/%s", chatDir, filename)
+	localPath := filepath.Join(chatDir, filename)
 
 	// Get absolute path
 	absPath, err := filepath.Abs(localPath)
@@ -1390,10 +1410,23 @@ func extractDirectPathFromURL(url string) string {
 	return "/" + pathPart
 }
 
+// withSecureHeaders wraps an http.HandlerFunc and sets a small set of
+// defensive response headers on every reply. These don't add functionality but
+// reduce the blast radius if something local tries to abuse the API surface
+// (e.g. a browser tab making a same-origin-bypassed request).
+func withSecureHeaders(h http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set("Referrer-Policy", "no-referrer")
+		h(w, r)
+	}
+}
+
 // Start a REST API server to expose the WhatsApp client functionality
 func startRESTServer(client *whatsmeow.Client, messageStore *MessageStore, port int) {
 	// Health check endpoint
-	http.HandleFunc("/api/health", func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc("/api/health", withSecureHeaders(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		status := map[string]interface{}{
 			"status":    "ok",
@@ -1405,10 +1438,10 @@ func startRESTServer(client *whatsmeow.Client, messageStore *MessageStore, port 
 			w.WriteHeader(http.StatusServiceUnavailable)
 		}
 		_ = json.NewEncoder(w).Encode(status)
-	})
+	}))
 
 	// Handler for sending messages
-	http.HandleFunc("/api/send", func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc("/api/send", withSecureHeaders(func(w http.ResponseWriter, r *http.Request) {
 		// Only allow POST requests
 		if r.Method != http.MethodPost {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -1433,11 +1466,18 @@ func startRESTServer(client *whatsmeow.Client, messageStore *MessageStore, port 
 			return
 		}
 
-		fmt.Println("Received request to send message", req.Message, req.MediaPath)
+		// Avoid logging req.Message verbatim — it's user content and may contain
+		// secrets (passwords, OTPs, tokens) the user pasted into a chat. Log only
+		// shape/metadata so operators can debug without leaking message bodies to
+		// stdout/log aggregators. The status string returned by sendWhatsAppMessage
+		// is bridge-controlled, so it's safe to log.
+		hasMedia := req.MediaPath != ""
+		fmt.Printf("→ /api/send recipient=%q message_len=%d has_media=%v\n",
+			req.Recipient, len(req.Message), hasMedia)
 
 		// Send the message
 		success, message := sendWhatsAppMessage(client, req.Recipient, req.Message, req.MediaPath)
-		fmt.Println("Message sent", success, message)
+		fmt.Printf("← /api/send success=%v status=%q\n", success, message)
 		// Set response headers
 		w.Header().Set("Content-Type", "application/json")
 
@@ -1451,10 +1491,10 @@ func startRESTServer(client *whatsmeow.Client, messageStore *MessageStore, port 
 			Success: success,
 			Message: message,
 		})
-	})
+	}))
 
 	// Handler for downloading media
-	http.HandleFunc("/api/download", func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc("/api/download", withSecureHeaders(func(w http.ResponseWriter, r *http.Request) {
 		// Only allow POST requests
 		if r.Method != http.MethodPost {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -1516,10 +1556,10 @@ func startRESTServer(client *whatsmeow.Client, messageStore *MessageStore, port 
 			Filename: filename,
 			Path:     path,
 		})
-	})
+	}))
 
 	// Handler for sending typing indicator
-	http.HandleFunc("/api/typing", func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc("/api/typing", withSecureHeaders(func(w http.ResponseWriter, r *http.Request) {
 		// Only allow POST requests
 		if r.Method != http.MethodPost {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -1592,7 +1632,7 @@ func startRESTServer(client *whatsmeow.Client, messageStore *MessageStore, port 
 				"message": fmt.Sprintf("Typing indicator set to %v", req.IsTyping),
 			})
 		}
-	})
+	}))
 
 	// Start the server with proper timeouts. Bind to loopback so the bridge is
 	// not reachable from the LAN; MCP clients talk to it over localhost.

--- a/whatsapp-bridge/webhook.go
+++ b/whatsapp-bridge/webhook.go
@@ -5,8 +5,12 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
+	"strings"
+	"sync"
 	"time"
 )
 
@@ -37,11 +41,82 @@ type WebhookPayload struct {
 	MediaBase64   string `json:"mediaBase64,omitempty"`
 }
 
+// validateWebhookURL parses the configured webhook URL and rejects values that
+// would silently send chat content (and base64 image data) somewhere unsafe.
+//
+// Rules:
+//   - scheme must be http or https
+//   - host must be present and parseable
+//   - if the host is non-loopback, scheme MUST be https (no plain-HTTP message
+//     content over the network). Set WEBHOOK_ALLOW_INSECURE=true to override
+//     for local-network/dev setups; this is logged loudly at startup.
+func validateWebhookURL(raw string) (*url.URL, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("WEBHOOK_URL is not a valid URL: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("WEBHOOK_URL scheme must be http or https, got %q", u.Scheme)
+	}
+	if u.Host == "" {
+		return nil, fmt.Errorf("WEBHOOK_URL is missing a host")
+	}
+
+	host := u.Hostname()
+	loopback := host == "localhost" || host == "::1"
+	if !loopback {
+		if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+			loopback = true
+		}
+	}
+
+	if !loopback && u.Scheme != "https" {
+		allow := strings.EqualFold(strings.TrimSpace(os.Getenv("WEBHOOK_ALLOW_INSECURE")), "true")
+		if !allow {
+			return nil, fmt.Errorf(
+				"WEBHOOK_URL points to a non-loopback host %q over plain HTTP; "+
+					"refusing to leak message content. Use https:// or set "+
+					"WEBHOOK_ALLOW_INSECURE=true to override at your own risk",
+				host,
+			)
+		}
+		fmt.Printf("⚠ WEBHOOK_ALLOW_INSECURE=true: sending message content over plain HTTP to %s\n", host)
+	}
+	return u, nil
+}
+
+// webhookURLOnce caches the validated webhook URL so we don't re-validate (and
+// re-log) for every message. validateErr is sticky: if the configured URL is
+// invalid we log once and skip webhook delivery for the lifetime of the process.
+var (
+	webhookURLOnce  sync.Once
+	webhookURLValue string
+	webhookURLErr   error
+)
+
+func resolveWebhookURL() (string, error) {
+	webhookURLOnce.Do(func() {
+		raw := os.Getenv("WEBHOOK_URL")
+		if raw == "" {
+			raw = "http://localhost:8769/whatsapp/webhook"
+		}
+		u, err := validateWebhookURL(raw)
+		if err != nil {
+			webhookURLErr = err
+			fmt.Printf("⚠ Disabling webhook: %v\n", err)
+			return
+		}
+		webhookURLValue = u.String()
+	})
+	return webhookURLValue, webhookURLErr
+}
+
 // sendWebhookPayload marshals and POSTs a WebhookPayload to the configured webhook URL.
 func sendWebhookPayload(payload WebhookPayload) {
-	webhookURL := os.Getenv("WEBHOOK_URL")
-	if webhookURL == "" {
-		webhookURL = "http://localhost:8769/whatsapp/webhook"
+	webhookURL, err := resolveWebhookURL()
+	if err != nil {
+		// Already logged once in resolveWebhookURL; stay quiet on the hot path.
+		return
 	}
 
 	jsonData, err := json.Marshal(payload)

--- a/whatsapp-bridge/webhook_test.go
+++ b/whatsapp-bridge/webhook_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestValidateWebhookURL covers the input rules enforced before any outbound
+// webhook delivery happens. The validator is conservative on purpose: when in
+// doubt it should error and the caller logs+disables delivery rather than
+// silently leaking message content.
+func TestValidateWebhookURL(t *testing.T) {
+	t.Setenv("WEBHOOK_ALLOW_INSECURE", "")
+
+	cases := []struct {
+		name      string
+		input     string
+		wantErr   bool
+		errSubstr string
+	}{
+		{name: "loopback http allowed", input: "http://localhost:8769/whatsapp/webhook"},
+		{name: "loopback ipv4 http allowed", input: "http://127.0.0.1:8769/hook"},
+		{name: "loopback ipv6 http allowed", input: "http://[::1]:8769/hook"},
+		{name: "remote https allowed", input: "https://example.com/hook"},
+		{name: "remote http rejected", input: "http://example.com/hook", wantErr: true, errSubstr: "plain HTTP"},
+		{name: "ftp scheme rejected", input: "ftp://localhost/hook", wantErr: true, errSubstr: "scheme"},
+		{name: "missing host rejected", input: "http:///hook", wantErr: true, errSubstr: "host"},
+		{name: "garbage rejected", input: "://not-a-url", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := validateWebhookURL(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got nil", tc.input)
+				}
+				if tc.errSubstr != "" && !strings.Contains(err.Error(), tc.errSubstr) {
+					t.Fatalf("expected error containing %q, got %v", tc.errSubstr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tc.input, err)
+			}
+		})
+	}
+}
+
+// TestValidateWebhookURLAllowInsecureOverride verifies that operators can
+// explicitly opt out of the HTTPS requirement for non-loopback hosts. This
+// matters for trusted local-network webhook receivers where TLS is genuinely
+// not feasible (e.g. Home Assistant on a LAN-only network).
+func TestValidateWebhookURLAllowInsecureOverride(t *testing.T) {
+	t.Setenv("WEBHOOK_ALLOW_INSECURE", "true")
+	if _, err := validateWebhookURL("http://192.168.1.50:8123/hook"); err != nil {
+		t.Fatalf("expected override to allow plain-HTTP LAN webhook, got error: %v", err)
+	}
+}

--- a/whatsapp-mcp-server/audio.py
+++ b/whatsapp-mcp-server/audio.py
@@ -1,6 +1,30 @@
 import os
+import shutil
 import subprocess
 import tempfile
+
+
+def _resolve_ffmpeg() -> str:
+    """Return an absolute path to the ffmpeg binary.
+
+    Resolving via shutil.which() at call time (and rejecting a missing binary)
+    means we surface a clear error instead of silently invoking an unexpected
+    "ffmpeg" found earlier on PATH. Setting FFMPEG_PATH lets users pin a
+    known-good absolute path (e.g. /opt/homebrew/bin/ffmpeg) and bypass PATH
+    lookup entirely.
+    """
+    pinned = os.environ.get("FFMPEG_PATH", "").strip()
+    if pinned:
+        if not os.path.isabs(pinned):
+            raise RuntimeError(f"FFMPEG_PATH must be an absolute path, got: {pinned!r}")
+        if not os.path.isfile(pinned) or not os.access(pinned, os.X_OK):
+            raise RuntimeError(f"FFMPEG_PATH does not point to an executable file: {pinned}")
+        return pinned
+
+    found = shutil.which("ffmpeg")
+    if not found:
+        raise RuntimeError("ffmpeg not found on PATH. Install ffmpeg or set FFMPEG_PATH to an absolute binary path.")
+    return found
 
 
 def convert_to_opus_ogg(input_file, output_file=None, bitrate="32k", sample_rate=24000):
@@ -33,9 +57,11 @@ def convert_to_opus_ogg(input_file, output_file=None, bitrate="32k", sample_rate
     if output_dir and not os.path.exists(output_dir):
         os.makedirs(output_dir)
 
-    # Build the ffmpeg command
+    # Build the ffmpeg command. Resolve to an absolute binary path so we don't
+    # silently pick up an unintended "ffmpeg" earlier on PATH.
+    ffmpeg_bin = _resolve_ffmpeg()
     cmd = [
-        "ffmpeg",
+        ffmpeg_bin,
         "-i",
         input_file,
         "-c:a",


### PR DESCRIPTION
# chore(security): defense-in-depth hardening

## What

A small, additive defense-in-depth pass on the bridge and MCP server. No
behavior change for the default-loopback setup. Each item is a discrete fix
that could ship independently — bundled here per CONTRIBUTING.md "one concern,
≤300 LOC" because they all live in the same security-hygiene category.

## Why

Found while reading through the codebase end-to-end. Nothing here is an active
exploit, but several are footguns that would bite someone who deviates from the
default loopback config (LAN setups, multi-user dev hosts, log aggregators
ingesting stdout). All fit in the "Security" bucket of `ROADMAP.md`:

> Bind defaults that fail safe (localhost first). Auditing of file/path inputs.

## Changes

### 1. `whatsapp-bridge`: stop logging message bodies on `/api/send`

`fmt.Println("Received request to send message", req.Message, ...)` wrote the
full message body to stdout on every send. Anyone tailing the bridge log (or
piping it into a log aggregator / launchd output file) would end up with a
plaintext copy of every outgoing WhatsApp message — including pasted
secrets/OTPs/tokens. Replaced with metadata-only logging
(`recipient`, `message_len`, `has_media`).

### 2. `whatsapp-bridge`: path-traversal guard on media storage

`downloadMedia` built `chatDir := "store/" + chatJID` with only `:` replaced.
`chatJID` is normally well-formed (whatsmeow-produced), but it ultimately
originates from the remote WhatsApp protocol. Defensively `filepath.Clean`-ing
+ asserting the resolved path stays inside `store/` removes a whole class of
"crafted JID escapes the storage dir" risk for free.

### 3. `whatsapp-bridge`: validate `WEBHOOK_URL` at startup

Previously a misconfigured `WEBHOOK_URL` (typo, missing scheme, or — more
importantly — a non-loopback `http://` URL) would silently succeed and stream
chat content + base64 image data plaintext over the network. Now:

- Scheme must be `http` or `https`.
- Host must be present.
- Non-loopback hosts require `https://`. Override with
  `WEBHOOK_ALLOW_INSECURE=true` (loud warning logged) for trusted-LAN
  receivers like Home Assistant.
- Validation runs once at first delivery; failures disable webhook output and
  log a single clear error rather than spamming on every message.

Includes `webhook_test.go` covering the matrix.

### 4. `whatsapp-bridge`: defensive response headers

Adds `X-Content-Type-Options: nosniff`, `Cache-Control: no-store`, and
`Referrer-Policy: no-referrer` to every REST response via a tiny
`withSecureHeaders` wrapper. Doesn't change functionality; reduces the
blast-radius of any local browser tab that bypasses same-origin and pokes at
`127.0.0.1:8080`.

### 5. `whatsapp-mcp-server`: pin ffmpeg resolution

`audio.py` invoked `ffmpeg` via PATH lookup, so a user-writable directory
earlier on `PATH` (e.g. a poisoned `~/.local/bin/ffmpeg`) silently took over
audio conversion. Added `_resolve_ffmpeg()`: prefers `FFMPEG_PATH` (must be an
absolute, executable file) and falls back to `shutil.which("ffmpeg")` with a
clear error if neither resolves.

## Out of scope (intentionally)

Mentioned only so reviewers know I considered them and chose not to bundle:

- **REST-API authentication** — proper bearer-token / Unix-socket fix needs
  design discussion (touches "authentication or network bind defaults" per
  CONTRIBUTING.md). Will open a separate issue / private security advisory.
- **`messages.db` at-rest encryption (SQLCipher)** — schema-impacting,
  warrants its own design discussion.
- **Rate-limiting `/api/send`** — needs a config story for the right limits
  and per-recipient vs global scope.

## Test plan

- [x] `uv run pytest -q` → 12 passed
- [x] `uv run ruff check .` → clean
- [x] `uv run ruff format --check .` → clean
- [ ] `golangci-lint run` (CI)
- [ ] `go build ./...` (CI)
- [ ] `go test ./...` (new `TestValidateWebhookURL` cases) (CI)

## Risk / rollback

Every change is purely additive on the default-loopback config — same defaults,
same behavior. The webhook validator can refuse to deliver if `WEBHOOK_URL` is
malformed, which is a *behavioral* change for misconfigured deploys — but
silent delivery to a typo'd URL was a footgun, not a feature. Rollback is
revert-the-PR; no migration state.
