### PR TITLE
Fix list_chats(include_last_message=False) returning empty list

### DIFF
--- a/whatsapp-mcp-server/whatsapp.py
+++ b/whatsapp-mcp-server/whatsapp.py
@@ -572,24 +572,37 @@ def list_chats(
         cursor = conn.cursor()
 
         # Build base query
-        query_parts = [
-            """
-            SELECT
-                chats.jid,
-                chats.name,
-                chats.last_message_time,
-                messages.content as last_message,
-                messages.sender as last_sender,
-                messages.is_from_me as last_is_from_me
-            FROM chats
-        """
-        ]
-
+        # Bug fix: cuando include_last_message=False, no podemos referenciar columnas
+        # de messages.* sin JOIN (resulta en "no such column: messages.content").
+        # Bug presente tanto en lharries/whatsapp-mcp como en verygoodplugins/whatsapp-mcp.
         if include_last_message:
-            query_parts.append("""
+            query_parts = [
+                """
+                SELECT
+                    chats.jid,
+                    chats.name,
+                    chats.last_message_time,
+                    messages.content as last_message,
+                    messages.sender as last_sender,
+                    messages.is_from_me as last_is_from_me
+                FROM chats
                 LEFT JOIN messages ON chats.jid = messages.chat_jid
                 AND chats.last_message_time = messages.timestamp
-            """)
+            """
+            ]
+        else:
+            query_parts = [
+                """
+                SELECT
+                    chats.jid,
+                    chats.name,
+                    chats.last_message_time,
+                    NULL as last_message,
+                    NULL as last_sender,
+                    NULL as last_is_from_me
+                FROM chats
+            """
+            ]
 
         where_clauses = []
         params = []


### PR DESCRIPTION
## Bug

`list_chats(include_last_message=False)` always returns `[]` instead of the chat list with `last_message=None`.

## Reproduction

```python
list_chats(include_last_message=False)  # returns []
list_chats(include_last_message=True)   # returns the actual chats
```

If you check the MCP server logs you'll see:

```
Database error: no such column: messages.content
```

The exception is caught and the function returns `[]`.

## Root cause

In `whatsapp.py::list_chats`, the SQL is constructed unconditionally to reference `messages.*`:

```sql
SELECT chats.jid, chats.name, chats.last_message_time,
       messages.content AS last_message,
       messages.sender AS last_sender,
       messages.is_from_me AS last_is_from_me
FROM chats
```

But the `LEFT JOIN messages ON ...` is only appended when `include_last_message=True`. With `False`, those `messages.*` columns aren't in scope and SQLite errors out.

## Fix

Split the two branches:

- `include_last_message=True`: keeps the existing query (LEFT JOIN + `messages.*` columns).
- `include_last_message=False`: uses `NULL AS last_message`, `NULL AS last_sender`, `NULL AS last_is_from_me`, and drops the JOIN entirely.

## Test plan

```python
list_chats(include_last_message=False)
# now returns the chats with last_message=None instead of []
```

```python
list_chats(include_last_message=True)
# behavior unchanged: returns chats with the actual last message text
```

In production use since 2026-04-30.
