### PR TITLE
fix(server): list_chats/get_chat error when include_last_message=False

### DIFF
--- a/whatsapp-mcp-server/tests/test_list_chats.py
+++ b/whatsapp-mcp-server/tests/test_list_chats.py
@@ -1,0 +1,127 @@
+"""Regression tests for list_chats / get_chat.
+
+The previous SQL referenced messages.* in the SELECT but only added the
+LEFT JOIN messages clause when include_last_message=True, so calling
+list_chats(include_last_message=False) errored out with
+"no such column: messages.content" and silently returned [].
+"""
+
+import sqlite3
+
+import pytest
+
+import whatsapp
+
+
+def _make_messages_db(path):
+    """Create a minimal messages.db that matches the real bridge schema."""
+    conn = sqlite3.connect(path)
+    cursor = conn.cursor()
+    cursor.executescript(
+        """
+        CREATE TABLE chats (
+            jid TEXT PRIMARY KEY,
+            name TEXT,
+            last_message_time TIMESTAMP
+        );
+        CREATE TABLE messages (
+            id TEXT,
+            chat_jid TEXT,
+            sender TEXT,
+            content TEXT,
+            timestamp TIMESTAMP,
+            is_from_me BOOLEAN,
+            media_type TEXT,
+            filename TEXT,
+            url TEXT,
+            media_key BLOB,
+            file_sha256 BLOB,
+            file_enc_sha256 BLOB,
+            file_length INTEGER,
+            PRIMARY KEY (id, chat_jid),
+            FOREIGN KEY (chat_jid) REFERENCES chats(jid)
+        );
+        """
+    )
+    cursor.execute(
+        "INSERT INTO chats (jid, name, last_message_time) VALUES (?, ?, ?)",
+        ("1234567890@s.whatsapp.net", "Alice", "2024-01-15 10:30:00+00:00"),
+    )
+    cursor.execute(
+        """INSERT INTO messages
+           (id, chat_jid, sender, content, timestamp, is_from_me)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        (
+            "msg1",
+            "1234567890@s.whatsapp.net",
+            "1234567890",
+            "hello world",
+            "2024-01-15 10:30:00+00:00",
+            0,
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture
+def messages_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "messages.db"
+    _make_messages_db(str(db_path))
+    monkeypatch.setattr(whatsapp, "MESSAGES_DB_PATH", str(db_path))
+    return db_path
+
+
+def test_list_chats_with_last_message(messages_db):
+    """Default behavior: include the joined last_message fields."""
+    chats = whatsapp.list_chats(limit=10)
+    assert len(chats) == 1
+    assert chats[0]["jid"] == "1234567890@s.whatsapp.net"
+    assert chats[0]["name"] == "Alice"
+    assert chats[0]["last_message"] == "hello world"
+    assert chats[0]["last_sender"] == "1234567890"
+
+
+def test_list_chats_without_last_message(messages_db):
+    """Regression: include_last_message=False must not error and must
+    still return the chat row with NULL last-message fields."""
+    chats = whatsapp.list_chats(limit=10, include_last_message=False)
+    assert len(chats) == 1
+    assert chats[0]["jid"] == "1234567890@s.whatsapp.net"
+    assert chats[0]["name"] == "Alice"
+    assert chats[0]["last_message"] is None
+    assert chats[0]["last_sender"] is None
+    assert chats[0]["last_is_from_me"] is None
+
+
+def test_list_chats_query_filter_with_include_last_message_false(messages_db):
+    """Filter by query while not including the last message — both code paths
+    should compose cleanly."""
+    chats = whatsapp.list_chats(query="Alice", include_last_message=False)
+    assert len(chats) == 1
+    assert chats[0]["name"] == "Alice"
+
+    chats = whatsapp.list_chats(query="Bob", include_last_message=False)
+    assert chats == []
+
+
+def test_get_chat_with_last_message(messages_db):
+    chat = whatsapp.get_chat("1234567890@s.whatsapp.net")
+    assert chat is not None
+    assert chat["name"] == "Alice"
+    assert chat["last_message"] == "hello world"
+
+
+def test_get_chat_without_last_message(messages_db):
+    """Regression: same bug existed in get_chat."""
+    chat = whatsapp.get_chat("1234567890@s.whatsapp.net", include_last_message=False)
+    assert chat is not None
+    assert chat["name"] == "Alice"
+    assert chat["last_message"] is None
+    assert chat["last_sender"] is None
+    assert chat["last_is_from_me"] is None
+
+
+def test_get_chat_missing_jid_returns_none(messages_db):
+    assert whatsapp.get_chat("nonexistent@s.whatsapp.net") is None
+    assert whatsapp.get_chat("nonexistent@s.whatsapp.net", include_last_message=False) is None

--- a/whatsapp-mcp-server/uv.lock
+++ b/whatsapp-mcp-server/uv.lock
@@ -903,7 +903,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.27.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0" },
     { name = "requests", specifier = ">=2.33.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.11" },
 ]

--- a/whatsapp-mcp-server/whatsapp.py
+++ b/whatsapp-mcp-server/whatsapp.py
@@ -583,11 +583,7 @@ def list_chats(
                 "messages.is_from_me as last_is_from_me"
             )
         else:
-            last_message_select = (
-                "NULL as last_message, "
-                "NULL as last_sender, "
-                "NULL as last_is_from_me"
-            )
+            last_message_select = "NULL as last_message, NULL as last_sender, NULL as last_is_from_me"
 
         query_parts = [
             f"""
@@ -857,17 +853,9 @@ def get_chat(chat_jid: str, include_last_message: bool = True) -> dict[str, Any]
         # include_last_message branch by emitting static NULLs when we
         # don't JOIN the messages table.
         if include_last_message:
-            last_message_select = (
-                "m.content as last_message, "
-                "m.sender as last_sender, "
-                "m.is_from_me as last_is_from_me"
-            )
+            last_message_select = "m.content as last_message, m.sender as last_sender, m.is_from_me as last_is_from_me"
         else:
-            last_message_select = (
-                "NULL as last_message, "
-                "NULL as last_sender, "
-                "NULL as last_is_from_me"
-            )
+            last_message_select = "NULL as last_message, NULL as last_sender, NULL as last_is_from_me"
 
         query = f"""
             SELECT

--- a/whatsapp-mcp-server/whatsapp.py
+++ b/whatsapp-mcp-server/whatsapp.py
@@ -571,16 +571,31 @@ def list_chats(
         conn = sqlite3.connect(MESSAGES_DB_PATH)
         cursor = conn.cursor()
 
-        # Build base query
+        # Build base query. The last-message columns are referenced by tuple
+        # index downstream, so we keep the result shape constant and emit
+        # static NULLs when the messages table is not joined — otherwise the
+        # SELECT references messages.* with no FROM/JOIN and SQLite errors
+        # out with "no such column: messages.content".
+        if include_last_message:
+            last_message_select = (
+                "messages.content as last_message, "
+                "messages.sender as last_sender, "
+                "messages.is_from_me as last_is_from_me"
+            )
+        else:
+            last_message_select = (
+                "NULL as last_message, "
+                "NULL as last_sender, "
+                "NULL as last_is_from_me"
+            )
+
         query_parts = [
-            """
+            f"""
             SELECT
                 chats.jid,
                 chats.name,
                 chats.last_message_time,
-                messages.content as last_message,
-                messages.sender as last_sender,
-                messages.is_from_me as last_is_from_me
+                {last_message_select}
             FROM chats
         """
         ]
@@ -838,14 +853,28 @@ def get_chat(chat_jid: str, include_last_message: bool = True) -> dict[str, Any]
         conn = sqlite3.connect(MESSAGES_DB_PATH)
         cursor = conn.cursor()
 
-        query = """
+        # See list_chats: keep result tuple shape stable across the
+        # include_last_message branch by emitting static NULLs when we
+        # don't JOIN the messages table.
+        if include_last_message:
+            last_message_select = (
+                "m.content as last_message, "
+                "m.sender as last_sender, "
+                "m.is_from_me as last_is_from_me"
+            )
+        else:
+            last_message_select = (
+                "NULL as last_message, "
+                "NULL as last_sender, "
+                "NULL as last_is_from_me"
+            )
+
+        query = f"""
             SELECT
                 c.jid,
                 c.name,
                 c.last_message_time,
-                m.content as last_message,
-                m.sender as last_sender,
-                m.is_from_me as last_is_from_me
+                {last_message_select}
             FROM chats c
         """
 


### PR DESCRIPTION
## Summary

`list_chats()` and `get_chat()` always referenced `messages.*` columns in their SELECT, but only added the `LEFT JOIN messages` clause when `include_last_message=True`. Calling either with `include_last_message=False` produced an SQLite error:

```
Database error: no such column: messages.content
```

The MCP layer swallowed it and silently returned `[]` / `None`, so the bug looked like "no chats found" to callers.

## Fix

Keep the result tuple shape stable across both branches by emitting static `NULL` columns when not joining. Downstream code reads by tuple index (`chat_data[3]`, `[4]`, `[5]`) so the unchanged shape avoids ripple changes in the `Chat` mapping.

## Repro (before fix)

```python
from whatsapp import list_chats
list_chats(include_last_message=False)
# stderr: Database error: no such column: messages.content
# returns: []
```

## Test plan

- [x] New `tests/test_list_chats.py` covers both functions with both flag values, plus query-filter composition
- [x] `uv run pytest tests/` — **18 passed** (12 existing + 6 new), 0 regressions
- [x] Manual verification via the `mcp__whatsapp__list_chats` tool — both `include_last_message=True` and `False` now return populated results

🤖 Generated with [Claude Code](https://claude.com/claude-code)