### PR TITLE
fix: send and track disappearing-message settings correctly

### DIFF
--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -889,7 +889,7 @@ func extractChatEphemeralFromMessage(msg *waProto.Message) ChatEphemeralSettings
 	}
 }
 
-func updateChatEphemeralSettingsFromProtocolMessage(messageStore *MessageStore, chatJID string, msg *waProto.Message, logger waLog.Logger) {
+func updateChatEphemeralSettingsFromProtocolMessage(messageStore *MessageStore, chatJID string, msg *waProto.Message, eventTimestamp int64, logger waLog.Logger) {
 	if msg == nil || msg.GetProtocolMessage() == nil {
 		return
 	}
@@ -901,8 +901,12 @@ func updateChatEphemeralSettingsFromProtocolMessage(messageStore *MessageStore, 
 
 	expiration := protoMsg.GetEphemeralExpiration()
 	settingTimestamp := protoMsg.GetEphemeralSettingTimestamp()
+	// Fall back to the carrier event's timestamp rather than time.Now() so a
+	// late-arriving older event doesn't get stamped "newer than" subsequent
+	// updates and then block them via the monotonic WHERE clause in
+	// UpdateChatEphemeralSettings.
 	if settingTimestamp == 0 {
-		settingTimestamp = time.Now().Unix()
+		settingTimestamp = eventTimestamp
 	}
 
 	if err := messageStore.UpdateChatEphemeralSettings(chatJID, expiration, settingTimestamp); err != nil {
@@ -1323,7 +1327,7 @@ func handleMessage(client *whatsmeow.Client, messageStore *MessageStore, msg *ev
 		logger.Warnf("Failed to store chat: %v", err)
 	}
 
-	updateChatEphemeralSettingsFromProtocolMessage(messageStore, chatJID, msg.Message, logger)
+	updateChatEphemeralSettingsFromProtocolMessage(messageStore, chatJID, msg.Message, msg.Info.Timestamp.Unix(), logger)
 
 	// Backfill ephemeral state from any regular message's ContextInfo.
 	// EPHEMERAL_SETTING ProtocolMessages and GroupInfo events only fire on

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -1071,7 +1071,11 @@ func sendWhatsAppMessage(client *whatsmeow.Client, messageStore *MessageStore, r
 		msg.Conversation = proto.String(message)
 	}
 
-	settings, err := messageStore.GetChatEphemeralSettings(settingsLookupJID.String())
+	// Normalize @lid recipients to phone JID before the lookup. Chats are
+	// persisted under @s.whatsapp.net (handleMessage normalizes via
+	// resolveLIDChat); without this step, an API caller passing an @lid
+	// recipient would silently miss the disappearing-message settings row.
+	settings, err := messageStore.GetChatEphemeralSettings(resolveUserJID(client, settingsLookupJID, types.EmptyJID).String())
 	if err != nil && err != sql.ErrNoRows {
 		return false, fmt.Sprintf("Error loading chat settings: %v", err)
 	}

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -731,12 +731,19 @@ func (store *MessageStore) GetChats() (map[string]time.Time, error) {
 	chats := make(map[string]time.Time)
 	for rows.Next() {
 		var jid string
-		var lastMessageTime time.Time
+		// last_message_time can be NULL — UpdateChatEphemeralSettings can
+		// create a chat row from a GroupInfo / ephemeral-setting event
+		// before any message has landed for that chat.
+		var lastMessageTime sql.NullTime
 		err := rows.Scan(&jid, &lastMessageTime)
 		if err != nil {
 			return nil, err
 		}
-		chats[jid] = lastMessageTime
+		if lastMessageTime.Valid {
+			chats[jid] = lastMessageTime.Time
+		} else {
+			chats[jid] = time.Time{}
+		}
 	}
 
 	return chats, nil

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -77,6 +77,11 @@ type MessageStore struct {
 	db *sql.DB
 }
 
+type ChatEphemeralSettings struct {
+	Expiration       uint32
+	SettingTimestamp int64
+}
+
 // Initialize message store
 func NewMessageStore() (*MessageStore, error) {
 	// Create directory for database if it doesn't exist
@@ -95,7 +100,9 @@ func NewMessageStore() (*MessageStore, error) {
 		CREATE TABLE IF NOT EXISTS chats (
 			jid TEXT PRIMARY KEY,
 			name TEXT,
-			last_message_time TIMESTAMP
+			last_message_time TIMESTAMP,
+			ephemeral_expiration INTEGER NOT NULL DEFAULT 0,
+			ephemeral_setting_timestamp INTEGER NOT NULL DEFAULT 0
 		);
 		
 		CREATE TABLE IF NOT EXISTS messages (
@@ -139,7 +146,51 @@ func NewMessageStore() (*MessageStore, error) {
 		return nil, fmt.Errorf("failed to create tables: %v", err)
 	}
 
+	if err := ensureMessageStoreSchema(db); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+
 	return &MessageStore{db: db}, nil
+}
+
+func ensureMessageStoreSchema(db *sql.DB) error {
+	if err := ensureColumn(db, "chats", "ephemeral_expiration", "INTEGER NOT NULL DEFAULT 0"); err != nil {
+		return fmt.Errorf("failed to ensure chats.ephemeral_expiration column: %w", err)
+	}
+	if err := ensureColumn(db, "chats", "ephemeral_setting_timestamp", "INTEGER NOT NULL DEFAULT 0"); err != nil {
+		return fmt.Errorf("failed to ensure chats.ephemeral_setting_timestamp column: %w", err)
+	}
+	return nil
+}
+
+func ensureColumn(db *sql.DB, tableName, columnName, columnSpec string) error {
+	rows, err := db.Query(fmt.Sprintf("PRAGMA table_info(%s)", tableName))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var cid int
+		var name string
+		var colType string
+		var notNull int
+		var dfltValue sql.NullString
+		var pk int
+		if err := rows.Scan(&cid, &name, &colType, &notNull, &dfltValue, &pk); err != nil {
+			return err
+		}
+		if name == columnName {
+			return nil
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	_, err = db.Exec(fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s %s", tableName, columnName, columnSpec))
+	return err
 }
 
 // MigrateLegacyLIDChatsToPhoneJIDs rewrites message/chat rows stored under
@@ -504,6 +555,30 @@ func (store *MessageStore) StoreChat(jid, name string, lastMessageTime time.Time
 	return err
 }
 
+func (store *MessageStore) UpdateChatEphemeralSettings(jid string, expiration uint32, settingTimestamp int64) error {
+	_, err := store.db.Exec(
+		`INSERT INTO chats (jid, name, last_message_time, ephemeral_expiration, ephemeral_setting_timestamp)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(jid) DO UPDATE SET
+			ephemeral_expiration = excluded.ephemeral_expiration,
+			ephemeral_setting_timestamp = excluded.ephemeral_setting_timestamp`,
+		jid, jid, time.Time{}, expiration, settingTimestamp,
+	)
+	return err
+}
+
+func (store *MessageStore) GetChatEphemeralSettings(jid string) (ChatEphemeralSettings, error) {
+	var settings ChatEphemeralSettings
+	err := store.db.QueryRow(
+		"SELECT ephemeral_expiration, ephemeral_setting_timestamp FROM chats WHERE jid = ?",
+		jid,
+	).Scan(&settings.Expiration, &settings.SettingTimestamp)
+	if err != nil {
+		return ChatEphemeralSettings{}, err
+	}
+	return settings, nil
+}
+
 // Store a message in the database
 func (store *MessageStore) StoreMessage(id, chatJID, sender, content string, timestamp time.Time, isFromMe bool,
 	mediaType, filename, url string, mediaKey, fileSHA256, fileEncSHA256 []byte, fileLength uint64) error {
@@ -708,6 +783,70 @@ func classifyMediaPath(mediaPath string) (whatsmeow.MediaType, string, string) {
 	}
 }
 
+func buildDisappearingMode() *waProto.DisappearingMode {
+	return &waProto.DisappearingMode{
+		Initiator: waProto.DisappearingMode_CHANGED_IN_CHAT.Enum(),
+		Trigger:   waProto.DisappearingMode_CHAT_SETTING.Enum(),
+	}
+}
+
+func mergeEphemeralContextInfo(existing *waProto.ContextInfo, settings ChatEphemeralSettings) *waProto.ContextInfo {
+	if existing == nil {
+		existing = &waProto.ContextInfo{}
+	}
+	existing.Expiration = proto.Uint32(settings.Expiration)
+	existing.EphemeralSettingTimestamp = proto.Int64(settings.SettingTimestamp)
+	existing.DisappearingMode = buildDisappearingMode()
+	return existing
+}
+
+func applyChatEphemeralSettings(msg *waProto.Message, settings ChatEphemeralSettings) {
+	if msg == nil || settings.Expiration == 0 || settings.SettingTimestamp == 0 {
+		return
+	}
+
+	switch {
+	case msg.ExtendedTextMessage != nil:
+		msg.ExtendedTextMessage.ContextInfo = mergeEphemeralContextInfo(msg.ExtendedTextMessage.GetContextInfo(), settings)
+	case msg.ImageMessage != nil:
+		msg.ImageMessage.ContextInfo = mergeEphemeralContextInfo(msg.ImageMessage.GetContextInfo(), settings)
+	case msg.AudioMessage != nil:
+		msg.AudioMessage.ContextInfo = mergeEphemeralContextInfo(msg.AudioMessage.GetContextInfo(), settings)
+	case msg.VideoMessage != nil:
+		msg.VideoMessage.ContextInfo = mergeEphemeralContextInfo(msg.VideoMessage.GetContextInfo(), settings)
+	case msg.DocumentMessage != nil:
+		msg.DocumentMessage.ContextInfo = mergeEphemeralContextInfo(msg.DocumentMessage.GetContextInfo(), settings)
+	case msg.Conversation != nil:
+		text := msg.GetConversation()
+		msg.Conversation = nil
+		msg.ExtendedTextMessage = &waProto.ExtendedTextMessage{
+			Text:        proto.String(text),
+			ContextInfo: mergeEphemeralContextInfo(nil, settings),
+		}
+	}
+}
+
+func updateChatEphemeralSettingsFromProtocolMessage(messageStore *MessageStore, chatJID string, msg *waProto.Message, logger waLog.Logger) {
+	if msg == nil || msg.GetProtocolMessage() == nil {
+		return
+	}
+
+	protoMsg := msg.GetProtocolMessage()
+	if protoMsg.GetType() != waProto.ProtocolMessage_EPHEMERAL_SETTING {
+		return
+	}
+
+	expiration := protoMsg.GetEphemeralExpiration()
+	settingTimestamp := protoMsg.GetEphemeralSettingTimestamp()
+	if settingTimestamp == 0 {
+		settingTimestamp = time.Now().Unix()
+	}
+
+	if err := messageStore.UpdateChatEphemeralSettings(chatJID, expiration, settingTimestamp); err != nil {
+		logger.Warnf("Failed to update ephemeral settings for %s: %v", chatJID, err)
+	}
+}
+
 // Function to send a WhatsApp message
 func sendWhatsAppMessage(client *whatsmeow.Client, messageStore *MessageStore, recipient string, message string, mediaPath string) (bool, string) {
 	if !client.IsConnected() {
@@ -854,6 +993,14 @@ func sendWhatsAppMessage(client *whatsmeow.Client, messageStore *MessageStore, r
 		}
 	} else {
 		msg.Conversation = proto.String(message)
+	}
+
+	settings, err := messageStore.GetChatEphemeralSettings(recipientJID.String())
+	if err != nil && err != sql.ErrNoRows {
+		return false, fmt.Sprintf("Error loading chat settings: %v", err)
+	}
+	if err == nil {
+		applyChatEphemeralSettings(msg, settings)
 	}
 
 	// Send message
@@ -1110,6 +1257,8 @@ func handleMessage(client *whatsmeow.Client, messageStore *MessageStore, msg *ev
 	if err != nil {
 		logger.Warnf("Failed to store chat: %v", err)
 	}
+
+	updateChatEphemeralSettingsFromProtocolMessage(messageStore, chatJID, msg.Message, logger)
 
 	// Extract text content
 	content := extractTextContent(msg.Message)
@@ -1773,6 +1922,17 @@ func main() {
 			// Process history sync events
 			handleHistorySync(client, messageStore, v, logger)
 
+		case *events.GroupInfo:
+			if v.Ephemeral != nil {
+				expiration := uint32(0)
+				if v.Ephemeral.IsEphemeral {
+					expiration = v.Ephemeral.DisappearingTimer
+				}
+				if err := messageStore.UpdateChatEphemeralSettings(v.JID.String(), expiration, v.Timestamp.Unix()); err != nil {
+					logger.Warnf("Failed to store group ephemeral settings for %s: %v", v.JID, err)
+				}
+			}
+
 		case *events.CallOffer:
 			// 1:1 incoming call. call_type defaults to "voice"; CallOffer
 			// doesn't expose Media directly (it's buried in the binary Data
@@ -2220,6 +2380,13 @@ func handleHistorySync(client *whatsmeow.Client, messageStore *MessageStore, his
 			timestamp := time.Unix(int64(ts), 0)
 
 			_ = messageStore.StoreChat(chatJID, name, timestamp)
+			if err := messageStore.UpdateChatEphemeralSettings(
+				chatJID,
+				conversation.GetEphemeralExpiration(),
+				conversation.GetEphemeralSettingTimestamp(),
+			); err != nil {
+				logger.Warnf("Failed to store history sync ephemeral settings for %s: %v", chatJID, err)
+			}
 
 			// Store messages
 			for _, msg := range messages {

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -555,13 +555,27 @@ func (store *MessageStore) StoreChat(jid, name string, lastMessageTime time.Time
 	return err
 }
 
+// UpdateChatEphemeralSettings records the chat's disappearing-message timer.
+// Writes are gated on settingTimestamp so that low-information events don't
+// clobber authoritative ones:
+//
+//   - settingTimestamp == 0: skip entirely. Sparse history-sync chunks and
+//     plain (non-ephemeral) messages deliver records with no ephemeral fields,
+//     and we must not interpret that absence as "the user turned it off".
+//   - settingTimestamp older than the stored one: skip. Out-of-order delivery
+//     (replays, late history-sync chunks, old messages flowing in) would
+//     otherwise downgrade newer state to older state.
 func (store *MessageStore) UpdateChatEphemeralSettings(jid string, expiration uint32, settingTimestamp int64) error {
+	if settingTimestamp == 0 {
+		return nil
+	}
 	_, err := store.db.Exec(
 		`INSERT INTO chats (jid, name, last_message_time, ephemeral_expiration, ephemeral_setting_timestamp)
 		VALUES (?, ?, ?, ?, ?)
 		ON CONFLICT(jid) DO UPDATE SET
 			ephemeral_expiration = excluded.ephemeral_expiration,
-			ephemeral_setting_timestamp = excluded.ephemeral_setting_timestamp`,
+			ephemeral_setting_timestamp = excluded.ephemeral_setting_timestamp
+		WHERE excluded.ephemeral_setting_timestamp >= chats.ephemeral_setting_timestamp`,
 		jid, jid, time.Time{}, expiration, settingTimestamp,
 	)
 	return err
@@ -823,6 +837,41 @@ func applyChatEphemeralSettings(msg *waProto.Message, settings ChatEphemeralSett
 			Text:        proto.String(text),
 			ContextInfo: mergeEphemeralContextInfo(nil, settings),
 		}
+	}
+}
+
+// extractChatEphemeralFromMessage reads the chat's ephemeral state off an
+// inbound message's ContextInfo. Every regular message in an ephemeral chat
+// stamps Expiration / EphemeralSettingTimestamp on the sub-message's
+// ContextInfo, which lets the bridge backfill chats whose disappearing state
+// was set before the bridge ever saw an EPHEMERAL_SETTING toggle or a
+// fresh history sync. Returns the zero ChatEphemeralSettings when no
+// ContextInfo is present (e.g. plain Conversation, ProtocolMessage).
+func extractChatEphemeralFromMessage(msg *waProto.Message) ChatEphemeralSettings {
+	if msg == nil {
+		return ChatEphemeralSettings{}
+	}
+	var ctx *waProto.ContextInfo
+	switch {
+	case msg.ExtendedTextMessage != nil:
+		ctx = msg.ExtendedTextMessage.GetContextInfo()
+	case msg.ImageMessage != nil:
+		ctx = msg.ImageMessage.GetContextInfo()
+	case msg.AudioMessage != nil:
+		ctx = msg.AudioMessage.GetContextInfo()
+	case msg.VideoMessage != nil:
+		ctx = msg.VideoMessage.GetContextInfo()
+	case msg.DocumentMessage != nil:
+		ctx = msg.DocumentMessage.GetContextInfo()
+	case msg.StickerMessage != nil:
+		ctx = msg.StickerMessage.GetContextInfo()
+	}
+	if ctx == nil {
+		return ChatEphemeralSettings{}
+	}
+	return ChatEphemeralSettings{
+		Expiration:       ctx.GetExpiration(),
+		SettingTimestamp: ctx.GetEphemeralSettingTimestamp(),
 	}
 }
 
@@ -1261,6 +1310,17 @@ func handleMessage(client *whatsmeow.Client, messageStore *MessageStore, msg *ev
 	}
 
 	updateChatEphemeralSettingsFromProtocolMessage(messageStore, chatJID, msg.Message, logger)
+
+	// Backfill ephemeral state from any regular message's ContextInfo.
+	// EPHEMERAL_SETTING ProtocolMessages and GroupInfo events only fire on
+	// changes, so chats whose disappearing timer was set before the bridge
+	// started (or before this code shipped) would otherwise stay invisible
+	// to outgoing-message logic.
+	if backfill := extractChatEphemeralFromMessage(msg.Message); backfill.SettingTimestamp != 0 {
+		if err := messageStore.UpdateChatEphemeralSettings(chatJID, backfill.Expiration, backfill.SettingTimestamp); err != nil {
+			logger.Warnf("Failed to backfill ephemeral settings for %s: %v", chatJID, err)
+		}
+	}
 
 	// Extract text content
 	content := extractTextContent(msg.Message)

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -169,8 +169,8 @@ func ensureColumn(db *sql.DB, tableName, columnName, columnSpec string) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = rows.Close() }()
 
+	exists := false
 	for rows.Next() {
 		var cid int
 		var name string
@@ -179,14 +179,24 @@ func ensureColumn(db *sql.DB, tableName, columnName, columnSpec string) error {
 		var dfltValue sql.NullString
 		var pk int
 		if err := rows.Scan(&cid, &name, &colType, &notNull, &dfltValue, &pk); err != nil {
+			_ = rows.Close()
 			return err
 		}
 		if name == columnName {
-			return nil
+			exists = true
 		}
 	}
 	if err := rows.Err(); err != nil {
+		_ = rows.Close()
 		return err
+	}
+	// Close before ALTER: SQLite holds a read lock while rows are open,
+	// which would make the schema change fail with "database is locked".
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	if exists {
+		return nil
 	}
 
 	_, err = db.Exec(fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s %s", tableName, columnName, columnSpec))
@@ -569,14 +579,18 @@ func (store *MessageStore) UpdateChatEphemeralSettings(jid string, expiration ui
 	if settingTimestamp == 0 {
 		return nil
 	}
+	// INSERT only the ephemeral columns; leave name/last_message_time NULL
+	// so a `GroupInfo` event firing before any StoreChat call doesn't
+	// fabricate placeholder metadata (raw JID as name, year-0001 timestamp)
+	// that would leak into list_chats output.
 	_, err := store.db.Exec(
-		`INSERT INTO chats (jid, name, last_message_time, ephemeral_expiration, ephemeral_setting_timestamp)
-		VALUES (?, ?, ?, ?, ?)
+		`INSERT INTO chats (jid, ephemeral_expiration, ephemeral_setting_timestamp)
+		VALUES (?, ?, ?)
 		ON CONFLICT(jid) DO UPDATE SET
 			ephemeral_expiration = excluded.ephemeral_expiration,
 			ephemeral_setting_timestamp = excluded.ephemeral_setting_timestamp
 		WHERE excluded.ephemeral_setting_timestamp >= chats.ephemeral_setting_timestamp`,
-		jid, jid, time.Time{}, expiration, settingTimestamp,
+		jid, expiration, settingTimestamp,
 	)
 	return err
 }

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -855,6 +855,7 @@ func sendWhatsAppMessage(client *whatsmeow.Client, messageStore *MessageStore, r
 
 	// Create JID for recipient
 	var recipientJID types.JID
+	var settingsLookupJID types.JID
 	var err error
 
 	// Check if recipient is a JID
@@ -873,6 +874,7 @@ func sendWhatsAppMessage(client *whatsmeow.Client, messageStore *MessageStore, r
 			Server: "s.whatsapp.net", // For personal chats
 		}
 	}
+	settingsLookupJID = recipientJID
 
 	// Capture pre-LID-resolution JID for SQLite storage.
 	// handleMessage uses resolveLIDChat to map LID→phone for incoming events;
@@ -995,7 +997,7 @@ func sendWhatsAppMessage(client *whatsmeow.Client, messageStore *MessageStore, r
 		msg.Conversation = proto.String(message)
 	}
 
-	settings, err := messageStore.GetChatEphemeralSettings(recipientJID.String())
+	settings, err := messageStore.GetChatEphemeralSettings(settingsLookupJID.String())
 	if err != nil && err != sql.ErrNoRows {
 		return false, fmt.Sprintf("Error loading chat settings: %v", err)
 	}

--- a/whatsapp-bridge/main_test.go
+++ b/whatsapp-bridge/main_test.go
@@ -76,7 +76,9 @@ func newTestMessageStore(t *testing.T) *MessageStore {
 		CREATE TABLE chats (
 			jid TEXT PRIMARY KEY,
 			name TEXT,
-			last_message_time TIMESTAMP
+			last_message_time TIMESTAMP,
+			ephemeral_expiration INTEGER NOT NULL DEFAULT 0,
+			ephemeral_setting_timestamp INTEGER NOT NULL DEFAULT 0
 		);
 		CREATE TABLE messages (
 			id TEXT,
@@ -115,6 +117,60 @@ func newTestMessageStore(t *testing.T) *MessageStore {
 	}
 	t.Cleanup(func() { _ = db.Close() })
 	return &MessageStore{db: db}
+}
+
+func TestStoreChatPreservesEphemeralSettings(t *testing.T) {
+	ms := newTestMessageStore(t)
+
+	chatJID := "15551234567@s.whatsapp.net"
+	if err := ms.UpdateChatEphemeralSettings(chatJID, 604800, 1710000000); err != nil {
+		t.Fatalf("failed to seed ephemeral settings: %v", err)
+	}
+
+	if err := ms.StoreChat(chatJID, "Alice", time.Unix(1710000100, 0)); err != nil {
+		t.Fatalf("failed to store chat: %v", err)
+	}
+
+	settings, err := ms.GetChatEphemeralSettings(chatJID)
+	if err != nil {
+		t.Fatalf("failed to load ephemeral settings: %v", err)
+	}
+	if settings.Expiration != 604800 {
+		t.Fatalf("expected expiration 604800, got %d", settings.Expiration)
+	}
+	if settings.SettingTimestamp != 1710000000 {
+		t.Fatalf("expected setting timestamp 1710000000, got %d", settings.SettingTimestamp)
+	}
+}
+
+func TestApplyChatEphemeralSettingsConvertsConversation(t *testing.T) {
+	msg := &waProto.Message{
+		Conversation: proto.String("hello"),
+	}
+
+	applyChatEphemeralSettings(msg, ChatEphemeralSettings{
+		Expiration:       604800,
+		SettingTimestamp: 1710000000,
+	})
+
+	if msg.Conversation != nil {
+		t.Fatalf("expected conversation to be converted to extended text")
+	}
+	if msg.GetExtendedTextMessage() == nil {
+		t.Fatalf("expected extended text message to be set")
+	}
+	if got := msg.GetExtendedTextMessage().GetText(); got != "hello" {
+		t.Fatalf("expected text hello, got %q", got)
+	}
+	if got := msg.GetExtendedTextMessage().GetContextInfo().GetExpiration(); got != 604800 {
+		t.Fatalf("expected expiration 604800, got %d", got)
+	}
+	if got := msg.GetExtendedTextMessage().GetContextInfo().GetEphemeralSettingTimestamp(); got != 1710000000 {
+		t.Fatalf("expected setting timestamp 1710000000, got %d", got)
+	}
+	if got := msg.GetExtendedTextMessage().GetContextInfo().GetDisappearingMode().GetTrigger(); got != waProto.DisappearingMode_CHAT_SETTING {
+		t.Fatalf("expected disappearing mode trigger CHAT_SETTING, got %v", got)
+	}
 }
 
 func testLogger() waLog.Logger {

--- a/whatsapp-bridge/main_test.go
+++ b/whatsapp-bridge/main_test.go
@@ -242,6 +242,11 @@ func TestExtractChatEphemeralFromMessage(t *testing.T) {
 			want: ChatEphemeralSettings{Expiration: 604800, SettingTimestamp: 1710000000},
 		},
 		{
+			name: "StickerMessage",
+			msg:  &waProto.Message{StickerMessage: &waProto.StickerMessage{ContextInfo: ctx}},
+			want: ChatEphemeralSettings{Expiration: 604800, SettingTimestamp: 1710000000},
+		},
+		{
 			name: "Conversation (no ContextInfo at all)",
 			msg:  &waProto.Message{Conversation: proto.String("plain text")},
 			want: ChatEphemeralSettings{},

--- a/whatsapp-bridge/main_test.go
+++ b/whatsapp-bridge/main_test.go
@@ -143,6 +143,169 @@ func TestStoreChatPreservesEphemeralSettings(t *testing.T) {
 	}
 }
 
+// TestUpdateChatEphemeralSettings_IgnoresZeroTimestamp pins down the sparse-chunk
+// guard: a write with settingTimestamp == 0 carries no information about when
+// the user toggled the chat's ephemeral state, so it must not clobber a
+// previously-captured non-zero value. WhatsApp's history sync delivers
+// Conversation records in many chunks; sparse later chunks omit the ephemeral
+// fields and would otherwise reset the row to (0, 0).
+func TestUpdateChatEphemeralSettings_IgnoresZeroTimestamp(t *testing.T) {
+	ms := newTestMessageStore(t)
+
+	chatJID := "15551234567@s.whatsapp.net"
+	if err := ms.UpdateChatEphemeralSettings(chatJID, 604800, 1710000000); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := ms.UpdateChatEphemeralSettings(chatJID, 0, 0); err != nil {
+		t.Fatalf("zero-ts write: %v", err)
+	}
+
+	settings, err := ms.GetChatEphemeralSettings(chatJID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if settings.Expiration != 604800 || settings.SettingTimestamp != 1710000000 {
+		t.Fatalf("expected sparse zero-ts write to be ignored; got (%d, %d)",
+			settings.Expiration, settings.SettingTimestamp)
+	}
+}
+
+// TestUpdateChatEphemeralSettings_IgnoresOlderTimestamp pins down the
+// monotonic-update rule: a write whose settingTimestamp is older than the
+// stored one is stale (out-of-order delivery) and must not overwrite. This
+// lets handleMessage safely write ephemeral-from-ContextInfo on every inbound
+// message without worrying about replays / late history-sync chunks.
+func TestUpdateChatEphemeralSettings_IgnoresOlderTimestamp(t *testing.T) {
+	ms := newTestMessageStore(t)
+
+	chatJID := "15551234567@s.whatsapp.net"
+	if err := ms.UpdateChatEphemeralSettings(chatJID, 604800, 1710000000); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// An older event (ts=1700000000) should not overwrite, even though both
+	// expiration and ts are non-zero.
+	if err := ms.UpdateChatEphemeralSettings(chatJID, 86400, 1700000000); err != nil {
+		t.Fatalf("older-ts write: %v", err)
+	}
+
+	settings, err := ms.GetChatEphemeralSettings(chatJID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if settings.Expiration != 604800 || settings.SettingTimestamp != 1710000000 {
+		t.Fatalf("expected older-ts write to be ignored; got (%d, %d)",
+			settings.Expiration, settings.SettingTimestamp)
+	}
+}
+
+// TestExtractChatEphemeralFromMessage covers every concrete sub-message type
+// that carries ContextInfo. Each regular message in an ephemeral chat stamps
+// ContextInfo.Expiration / EphemeralSettingTimestamp; the bridge backfills
+// from this so it doesn't depend on receiving a live EPHEMERAL_SETTING toggle
+// or a fresh history sync.
+func TestExtractChatEphemeralFromMessage(t *testing.T) {
+	ctx := &waProto.ContextInfo{
+		Expiration:                proto.Uint32(604800),
+		EphemeralSettingTimestamp: proto.Int64(1710000000),
+	}
+
+	cases := []struct {
+		name string
+		msg  *waProto.Message
+		want ChatEphemeralSettings
+	}{
+		{
+			name: "ExtendedTextMessage",
+			msg:  &waProto.Message{ExtendedTextMessage: &waProto.ExtendedTextMessage{ContextInfo: ctx}},
+			want: ChatEphemeralSettings{Expiration: 604800, SettingTimestamp: 1710000000},
+		},
+		{
+			name: "ImageMessage",
+			msg:  &waProto.Message{ImageMessage: &waProto.ImageMessage{ContextInfo: ctx}},
+			want: ChatEphemeralSettings{Expiration: 604800, SettingTimestamp: 1710000000},
+		},
+		{
+			name: "VideoMessage",
+			msg:  &waProto.Message{VideoMessage: &waProto.VideoMessage{ContextInfo: ctx}},
+			want: ChatEphemeralSettings{Expiration: 604800, SettingTimestamp: 1710000000},
+		},
+		{
+			name: "AudioMessage",
+			msg:  &waProto.Message{AudioMessage: &waProto.AudioMessage{ContextInfo: ctx}},
+			want: ChatEphemeralSettings{Expiration: 604800, SettingTimestamp: 1710000000},
+		},
+		{
+			name: "DocumentMessage",
+			msg:  &waProto.Message{DocumentMessage: &waProto.DocumentMessage{ContextInfo: ctx}},
+			want: ChatEphemeralSettings{Expiration: 604800, SettingTimestamp: 1710000000},
+		},
+		{
+			name: "Conversation (no ContextInfo at all)",
+			msg:  &waProto.Message{Conversation: proto.String("plain text")},
+			want: ChatEphemeralSettings{},
+		},
+		{
+			name: "Nil",
+			msg:  nil,
+			want: ChatEphemeralSettings{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractChatEphemeralFromMessage(tc.msg)
+			if got != tc.want {
+				t.Errorf("extractChatEphemeralFromMessage() = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestHandleMessage_BackfillsEphemeralFromContextInfo asserts the end-to-end
+// backfill: an inbound regular message whose ContextInfo carries a
+// non-zero EphemeralSettingTimestamp must update the chat's ephemeral
+// settings row, so subsequent outgoing messages from the bridge respect the
+// chat's disappearing-message timer.
+func TestHandleMessage_BackfillsEphemeralFromContextInfo(t *testing.T) {
+	client := newTestClient(&mockLIDStore{})
+	ms := newTestMessageStore(t)
+	logger := testLogger()
+
+	msg := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Chat:     phonePN,
+				Sender:   phonePN,
+				IsFromMe: false,
+			},
+			ID:        "ephemeral-backfill-001",
+			Timestamp: time.Now(),
+		},
+		Message: &waProto.Message{
+			ExtendedTextMessage: &waProto.ExtendedTextMessage{
+				Text: proto.String("hi from a disappearing chat"),
+				ContextInfo: &waProto.ContextInfo{
+					Expiration:                proto.Uint32(604800),
+					EphemeralSettingTimestamp: proto.Int64(1710000000),
+				},
+			},
+		},
+	}
+
+	handleMessage(client, ms, msg, logger)
+
+	settings, err := ms.GetChatEphemeralSettings(phonePN.String())
+	if err != nil {
+		t.Fatalf("get ephemeral settings: %v", err)
+	}
+	if settings.Expiration != 604800 || settings.SettingTimestamp != 1710000000 {
+		t.Fatalf("expected handleMessage to backfill (604800, 1710000000); got (%d, %d)",
+			settings.Expiration, settings.SettingTimestamp)
+	}
+}
+
 func TestApplyChatEphemeralSettingsConvertsConversation(t *testing.T) {
 	msg := &waProto.Message{
 		Conversation: proto.String("hello"),


### PR DESCRIPTION
## Summary

Three related fixes so the bridge handles WhatsApp's disappearing-message (ephemeral) settings correctly when sending and persisting state:

- **Respect disappearing settings when sending** (d5f104e): outgoing messages now stamp the chat's `Expiration` / `EphemeralSettingTimestamp` on the message context, so recipients/groups treat them as disappearing.
- **Look up DM ephemeral settings by phone chat jid** (b9396bf): DM lookups were using the LID-form jid and missing the row, so DMs sent without ephemeral context even when the chat had a timer set.
- **Backfill chat ephemeral settings from inbound `ContextInfo`** (327ed34): chats whose timer was set before the bridge ever saw an `EPHEMERAL_SETTING` / `GroupInfo` / fresh history-sync record stayed at `(0, 0)`. Every regular inbound message in an ephemeral chat now stamps the fields onto its sub-message `ContextInfo`, so `handleMessage` extracts them and updates the chat row. Also gates `UpdateChatEphemeralSettings` on `settingTimestamp` so sparse history-sync chunks and out-of-order replays cannot clobber a known-good value with zeros or older state.

## Test plan

Unit tests added in `whatsapp-bridge/main_test.go`:

- [ ] `go test ./whatsapp-bridge/...` passes
  - `TestStoreChatPreservesEphemeralSettings`
  - `TestUpdateChatEphemeralSettings_IgnoresZeroTimestamp`
  - `TestUpdateChatEphemeralSettings_IgnoresOlderTimestamp`
  - `TestExtractChatEphemeralFromMessage`
  - `TestHandleMessage_BackfillsEphemeralFromContextInfo`
  - `TestApplyChatEphemeralSettingsConvertsConversation`
- [ ] Manual: enable disappearing messages on a DM and a group; send from the bridge; confirm the recipient sees them as disappearing.
- [ ] Manual: connect the bridge to an account with pre-existing disappearing chats (no recent `EPHEMERAL_SETTING` event) and confirm a few inbound messages later the chat row reflects the correct timer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)