### PR TITLE
fix(bridge): store outbound messages in local DB at send time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ package-lock.json
 # Go binaries
 whatsapp-bridge/whatsapp-bridge
 whatsapp-bridge/whatsapp-client
+whatsapp-bridge/whatsapp-bridge.bak-*
+whatsapp-bridge/whatsapp-bridge.new
 *.exe
 
 # WhatsApp data (personal/sensitive)

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -667,7 +667,7 @@ type SendMessageRequest struct {
 }
 
 // Function to send a WhatsApp message
-func sendWhatsAppMessage(client *whatsmeow.Client, recipient string, message string, mediaPath string) (bool, string) {
+func sendWhatsAppMessage(client *whatsmeow.Client, messageStore *MessageStore, recipient string, message string, mediaPath string) (bool, string) {
 	if !client.IsConnected() {
 		return false, "Not connected to WhatsApp"
 	}
@@ -692,6 +692,10 @@ func sendWhatsAppMessage(client *whatsmeow.Client, recipient string, message str
 			Server: "s.whatsapp.net", // For personal chats
 		}
 	}
+
+	// Preserve the phone/group JID for local DB storage, since LID resolution
+	// below rewrites recipientJID to @lid form for sending but queries use phone JID.
+	storageChatJID := recipientJID.String()
 
 	// For personal chats, resolve phone number JID to LID (Linked Identity).
 	// WhatsApp is migrating to LID-based addressing; messages sent to the
@@ -850,10 +854,37 @@ func sendWhatsAppMessage(client *whatsmeow.Client, recipient string, message str
 	}
 
 	// Send message
-	_, err = client.SendMessage(context.Background(), recipientJID, msg)
+	sendResp, err := client.SendMessage(context.Background(), recipientJID, msg)
 
 	if err != nil {
 		return false, fmt.Sprintf("Error sending message: %v", err)
+	}
+
+	// Store the outbound message locally so it appears in queries immediately,
+	// without waiting for the next WhatsApp HistorySync on reconnect.
+	if messageStore != nil {
+		ownJID := ""
+		if client.Store != nil && client.Store.ID != nil {
+			ownJID = client.Store.ID.User
+		}
+		storeErr := messageStore.StoreMessage(
+			sendResp.ID,
+			storageChatJID,
+			ownJID,
+			message,
+			sendResp.Timestamp,
+			true,
+			"", "", "",
+			nil, nil, nil, 0,
+		)
+		if storeErr != nil {
+			fmt.Printf("Warning: failed to store outbound message locally: %v\n", storeErr)
+		} else {
+			fmt.Printf("[%s] → %s: %s\n",
+				sendResp.Timestamp.Format("2006-01-02 15:04:05"),
+				storageChatJID,
+				message)
+		}
 	}
 
 	return true, fmt.Sprintf("Message sent to %s", recipient)
@@ -1436,7 +1467,7 @@ func startRESTServer(client *whatsmeow.Client, messageStore *MessageStore, port 
 		fmt.Println("Received request to send message", req.Message, req.MediaPath)
 
 		// Send the message
-		success, message := sendWhatsAppMessage(client, req.Recipient, req.Message, req.MediaPath)
+		success, message := sendWhatsAppMessage(client, messageStore, req.Recipient, req.Message, req.MediaPath)
 		fmt.Println("Message sent", success, message)
 		// Set response headers
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## Summary

`/api/send` previously delivered messages via whatsmeow but never called `StoreMessage`, leaving outbound rows missing from the SQLite store until the next HistorySync on reconnect backfilled them. In practice many outbound messages never backfilled at all, so they were missing from local queries.

This change has `sendWhatsAppMessage` store the sent message immediately after a successful `client.SendMessage`, using the pre-LID-resolution JID so rows align with how inbound messages and HistorySync normalize `chat_jid`.

## Changes

- `sendWhatsAppMessage` now takes a `*MessageStore` parameter and stores the outbound message after a successful send
- Captures the chat JID before LID resolution, so storage matches inbound + HistorySync conventions
- Uses `sendResp.ID` and `sendResp.Timestamp` from whatsmeow's response so the stored row matches what WhatsApp acknowledged
- Logs failures as warnings (storage failure does not fail the send)
- gitignore: adds `whatsapp-bridge.bak-*` and `whatsapp-bridge.new` (safety copies created during hot-swap of the binary)

## Why this matters

Without this fix, applications consuming the local SQLite store cannot rely on it as the source of truth for outbound messages — they have to wait for HistorySync, which is unreliable. With this fix, outbound messages are immediately visible to any consumer reading the DB.

## Test plan

- [x] Send a personal message via /api/send → row appears in messages table immediately with from_me=1
- [x] Send a group message → row appears with the group JID (not the LID-resolved form)
- [x] Send fails (e.g. recipient not migrated) → no orphaned row in DB
- [x] Storage failure does not break the send response

## Notes

Running this in production for ~2 weeks against a WhatsApp Business account with no issues. Happy to adjust style or split commits if helpful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)