### PR TITLE
refactor(bridge): share recipient JID resolution

### DIFF
--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -921,40 +921,23 @@ func updateChatEphemeralSettingsFromProtocolMessage(messageStore *MessageStore, 
 	}
 }
 
-// Function to send a WhatsApp message
-func sendWhatsAppMessage(client *whatsmeow.Client, messageStore *MessageStore, recipient string, message string, mediaPath string) (bool, string) {
-	if !client.IsConnected() {
-		return false, "Not connected to WhatsApp"
-	}
-
-	// Create JID for recipient
+// resolveRecipientJID parses a phone number or JID string and resolves PN -> LID
+// for personal chats before sending.
+func resolveRecipientJID(client *whatsmeow.Client, recipient string) (types.JID, error) {
 	var recipientJID types.JID
-	var settingsLookupJID types.JID
 	var err error
 
-	// Check if recipient is a JID
-	isJID := strings.Contains(recipient, "@")
-
-	if isJID {
-		// Parse the JID string
+	if strings.Contains(recipient, "@") {
 		recipientJID, err = types.ParseJID(recipient)
 		if err != nil {
-			return false, fmt.Sprintf("Error parsing JID: %v", err)
+			return types.JID{}, fmt.Errorf("Error parsing JID: %v", err)
 		}
 	} else {
-		// Create JID from phone number
 		recipientJID = types.JID{
 			User:   recipient,
 			Server: "s.whatsapp.net", // For personal chats
 		}
 	}
-	settingsLookupJID = recipientJID
-
-	// Capture pre-LID-resolution JID for SQLite storage.
-	// handleMessage uses resolveLIDChat to map LID→phone for incoming events;
-	// for outbound we keep the pre-resolution form so the chat stays unified
-	// under @s.whatsapp.net (matches what list_chats / list_messages expect).
-	storageJID := recipientJID
 
 	// For personal chats, resolve phone number JID to LID (Linked Identity).
 	// WhatsApp is migrating to LID-based addressing; messages sent to the
@@ -978,6 +961,41 @@ func sendWhatsAppMessage(client *whatsmeow.Client, messageStore *MessageStore, r
 				recipientJID = userInfo.LID
 			}
 		}
+	}
+
+	return recipientJID, nil
+}
+
+// Function to send a WhatsApp message
+func sendWhatsAppMessage(client *whatsmeow.Client, messageStore *MessageStore, recipient string, message string, mediaPath string) (bool, string) {
+	if !client.IsConnected() {
+		return false, "Not connected to WhatsApp"
+	}
+
+	var settingsLookupJID types.JID
+	var err error
+
+	if strings.Contains(recipient, "@") {
+		settingsLookupJID, err = types.ParseJID(recipient)
+		if err != nil {
+			return false, fmt.Sprintf("Error parsing JID: %v", err)
+		}
+	} else {
+		settingsLookupJID = types.JID{
+			User:   recipient,
+			Server: "s.whatsapp.net", // For personal chats
+		}
+	}
+
+	// Capture pre-LID-resolution JID for SQLite storage.
+	// handleMessage uses resolveLIDChat to map LID→phone for incoming events;
+	// for outbound we keep the pre-resolution form so the chat stays unified
+	// under @s.whatsapp.net (matches what list_chats / list_messages expect).
+	storageJID := settingsLookupJID
+
+	recipientJID, err := resolveRecipientJID(client, recipient)
+	if err != nil {
+		return false, err.Error()
 	}
 
 	msg := &waProto.Message{}
@@ -1764,7 +1782,7 @@ func startRESTServer(client *whatsmeow.Client, messageStore *MessageStore, port 
 			req.Recipient, len(req.Message), resolvedMediaPath != "")
 
 		// Send the message
-		success, message := sendWhatsAppMessage(client, req.Recipient, req.Message, resolvedMediaPath)
+		success, message := sendWhatsAppMessage(client, messageStore, req.Recipient, req.Message, resolvedMediaPath)
 		fmt.Printf("← /api/send success=%v status=%q\n", success, message)
 		// Set response headers
 		w.Header().Set("Content-Type", "application/json")

--- a/whatsapp-bridge/main_test.go
+++ b/whatsapp-bridge/main_test.go
@@ -27,7 +27,15 @@ import (
 // mockLIDStore implements store.LIDStore with a simple in-memory map.
 type mockLIDStore struct {
 	store.NoopStore
+	lidByPN map[types.JID]types.JID
 	pnByLID map[types.JID]types.JID
+}
+
+func (m *mockLIDStore) GetLIDForPN(_ context.Context, pn types.JID) (types.JID, error) {
+	if lid, ok := m.lidByPN[pn]; ok {
+		return lid, nil
+	}
+	return types.EmptyJID, nil
 }
 
 func (m *mockLIDStore) GetPNForLID(_ context.Context, lid types.JID) (types.JID, error) {
@@ -140,6 +148,23 @@ func TestStoreChatPreservesEphemeralSettings(t *testing.T) {
 	}
 	if settings.SettingTimestamp != 1710000000 {
 		t.Fatalf("expected setting timestamp 1710000000, got %d", settings.SettingTimestamp)
+	}
+}
+
+func TestResolveRecipientJIDResolvesPhoneToCachedLID(t *testing.T) {
+	phoneJID := types.JID{User: "15551234567", Server: types.DefaultUserServer}
+	lidJID := types.JID{User: "123456789012345", Server: types.HiddenUserServer}
+	client := newTestClient(&mockLIDStore{
+		lidByPN: map[types.JID]types.JID{phoneJID: lidJID},
+	})
+
+	got, err := resolveRecipientJID(client, phoneJID.User)
+	if err != nil {
+		t.Fatalf("resolveRecipientJID returned error: %v", err)
+	}
+
+	if got != lidJID {
+		t.Fatalf("expected cached LID %s, got %s", lidJID, got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Extract shared outbound recipient parsing and PN-to-LID resolution into `resolveRecipientJID`.
- Keep outbound message storage and disappearing-message settings keyed from the pre-resolution JID.
- Pass `messageStore` through the `/api/send` handler to match the current `sendWhatsAppMessage` signature on `main`.

## Breaking Changes

None.

## Tests

- `go test ./...`
- `go build ./...`