### PR TITLE
chore: ignore local /store runtime directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ build/
 .pytest_cache/
 .coverage
 htmlcov/
+/store


### PR DESCRIPTION
## Summary
- Add `/store` to `.gitignore` so the whatsapp-bridge's local SQLite DBs and per-chat media (written to `./store` at the repo root during local runs) don't show up as tracked changes.

## Test plan
- [x] `git status` after a local bridge run shows a clean tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)