### PR TITLE
fix(bridge): set FileName and detect MIME for document sends

### DIFF
--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"mime"
 	"net/http"
 	"os"
 	"os/signal"
@@ -814,6 +815,9 @@ func classifyMediaPath(mediaPath string) (whatsmeow.MediaType, string, string) {
 	case "mov":
 		return whatsmeow.MediaVideo, "video/quicktime", "video"
 	default:
+		if m := mime.TypeByExtension("." + ext); m != "" {
+			return whatsmeow.MediaDocument, m, "document"
+		}
 		return whatsmeow.MediaDocument, "application/octet-stream", "document"
 	}
 }
@@ -1075,6 +1079,7 @@ func sendWhatsAppMessage(client *whatsmeow.Client, messageStore *MessageStore, r
 		case whatsmeow.MediaDocument:
 			msg.DocumentMessage = &waProto.DocumentMessage{
 				Title:         proto.String(mediaPath[strings.LastIndex(mediaPath, "/")+1:]),
+				FileName:      proto.String(mediaPath[strings.LastIndex(mediaPath, "/")+1:]),
 				Caption:       proto.String(message),
 				Mimetype:      proto.String(mimeType),
 				URL:           &resp.URL,


### PR DESCRIPTION
## Summary

- `DocumentMessage` now sets `FileName` alongside `Title`, so documents sent via `/api/send` display with their real filename and the correct file-type icon instead of "Untitled".
- `classifyMediaPath` falls back to `mime.TypeByExtension` before defaulting to `application/octet-stream`, so common document types (pdf, docx, xlsx, pptx, zip, txt, …) get their real MIME type and WhatsApp renders previews.

Closes #94.

## Type of change

- [x] `fix` — bug fix

## Scope check

- [x] Fits the [`ROADMAP.md`](https://github.com/verygoodplugins/whatsapp-mcp/blob/main/ROADMAP.md) "Media handling: ... MIME types, captions" in-scope bullet
- [x] PR is focused on one concern
- [x] PR is ≤ ~300 LOC (5 lines added)

## Linked issues

Closes #94

## Testing

Reproduced and verified end-to-end against the running bridge on macOS:

1. Started the bridge on `origin/main` (no patch). Sent a PDF — appeared as "Untitled", generic icon, no preview (matches #94).
2. Switched to this branch, rebuilt, sent the same PDF — appeared with the real filename, red PDF icon, "pdf" type label, and a first-page thumbnail preview.

Screenshots are attached to the linked issue #94 (before/after).

- [ ] Added or updated tests — _the affected code path (proto construction inside `sendWhatsAppMessage`) is not covered by the existing Go test suite; happy to add a focused unit test if you'd like_
- [x] Ran `go build ./...` and `go vet ./...` (Go changes — clean)
- [x] Manually exercised the affected code path end-to-end on a real WhatsApp account

## Docs

No user-visible API change; no doc updates needed.

## Risk / rollback

Minimal — adds one proto field on the outgoing `DocumentMessage` and one fallback branch in `classifyMediaPath`. Revertible by reverting the single commit.
