### PR TITLE
fix(bridge): log send caller identity

### DIFF
--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -1745,6 +1745,8 @@ func startRESTServer(client *whatsmeow.Client, messageStore *MessageStore, port 
 			return
 		}
 
+		fmt.Printf("→ /api/send from=%q user_agent=%q\n", r.RemoteAddr, r.UserAgent())
+
 		// Parse the request body
 		var req SendMessageRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -1716,14 +1716,15 @@ func extractDirectPathFromURL(url string) string {
 // Outbound media: req.MediaPath in /api/send is validated against
 // allowedMediaRoots before sendWhatsAppMessage ever sees it. See
 // media_path.go.
-func startRESTServer(client *whatsmeow.Client, messageStore *MessageStore, port int, token string, allowedMediaRoots []string) {
+func newRESTMux(client *whatsmeow.Client, messageStore *MessageStore, port int, token string, allowedMediaRoots []string) *http.ServeMux {
 	allowedHosts := buildAllowedHosts(port)
 	auth := func(h http.HandlerFunc) http.HandlerFunc {
 		return withAuth(token, allowedHosts, h)
 	}
+	mux := http.NewServeMux()
 
 	// Health check endpoint
-	http.HandleFunc("/api/health", auth(func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/health", auth(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		status := map[string]interface{}{
 			"status":    "ok",
@@ -1738,7 +1739,7 @@ func startRESTServer(client *whatsmeow.Client, messageStore *MessageStore, port 
 	}))
 
 	// Handler for sending messages
-	http.HandleFunc("/api/send", auth(func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/send", auth(func(w http.ResponseWriter, r *http.Request) {
 		// Only allow POST requests
 		if r.Method != http.MethodPost {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -1807,7 +1808,7 @@ func startRESTServer(client *whatsmeow.Client, messageStore *MessageStore, port 
 	}))
 
 	// Handler for downloading media
-	http.HandleFunc("/api/download", auth(func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/download", auth(func(w http.ResponseWriter, r *http.Request) {
 		// Only allow POST requests
 		if r.Method != http.MethodPost {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -1872,7 +1873,7 @@ func startRESTServer(client *whatsmeow.Client, messageStore *MessageStore, port 
 	}))
 
 	// Handler for sending typing indicator
-	http.HandleFunc("/api/typing", auth(func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/typing", auth(func(w http.ResponseWriter, r *http.Request) {
 		// Only allow POST requests
 		if r.Method != http.MethodPost {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -1947,6 +1948,12 @@ func startRESTServer(client *whatsmeow.Client, messageStore *MessageStore, port 
 		}
 	}))
 
+	return mux
+}
+
+func startRESTServer(client *whatsmeow.Client, messageStore *MessageStore, port int, token string, allowedMediaRoots []string) {
+	handler := newRESTMux(client, messageStore, port, token, allowedMediaRoots)
+
 	// Start the server with proper timeouts. Bind to loopback so the bridge is
 	// not reachable from the LAN; MCP clients talk to it over localhost.
 	serverAddr := fmt.Sprintf("127.0.0.1:%d", port)
@@ -1958,6 +1965,7 @@ func startRESTServer(client *whatsmeow.Client, messageStore *MessageStore, port 
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 60 * time.Second, // Longer for media downloads
 		IdleTimeout:  120 * time.Second,
+		Handler:      handler,
 	}
 
 	// Run server in a goroutine so it doesn't block

--- a/whatsapp-bridge/main_test.go
+++ b/whatsapp-bridge/main_test.go
@@ -5,9 +5,13 @@ import (
 	"database/sql"
 	"encoding/json"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -125,6 +129,87 @@ func newTestMessageStore(t *testing.T) *MessageStore {
 	}
 	t.Cleanup(func() { _ = db.Close() })
 	return &MessageStore{db: db}
+}
+
+func freeTCPPort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to allocate free TCP port: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	_, portString, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatalf("failed to split listener address: %v", err)
+	}
+	port, err := strconv.Atoi(portString)
+	if err != nil {
+		t.Fatalf("failed to parse listener port: %v", err)
+	}
+	return port
+}
+
+func TestSendHandlerLogsCallerBeforeDecode(t *testing.T) {
+	const token = "supersecrettoken1234567890abcdef"
+	port := freeTCPPort(t)
+	oldMux := http.DefaultServeMux
+	http.DefaultServeMux = http.NewServeMux()
+	t.Cleanup(func() {
+		http.DefaultServeMux = oldMux
+	})
+
+	readPipe, writePipe, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create stdout pipe: %v", err)
+	}
+	oldStdout := os.Stdout
+	os.Stdout = writePipe
+
+	startRESTServer(newTestClient(&mockLIDStore{}), newTestMessageStore(t), port, token, nil)
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	var resp *http.Response
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		req, reqErr := http.NewRequest(
+			http.MethodPost,
+			"http://127.0.0.1:"+strconv.Itoa(port)+"/api/send",
+			strings.NewReader("{"),
+		)
+		if reqErr != nil {
+			t.Fatalf("failed to create request: %v", reqErr)
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("User-Agent", "unit-test-fingerprint")
+		resp, err = client.Do(req)
+		if err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	os.Stdout = oldStdout
+	_ = writePipe.Close()
+	outputBytes, readErr := io.ReadAll(readPipe)
+	_ = readPipe.Close()
+	if readErr != nil {
+		t.Fatalf("failed to read captured stdout: %v", readErr)
+	}
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected malformed body to return 400, got %d", resp.StatusCode)
+	}
+
+	output := string(outputBytes)
+	if !strings.Contains(output, "→ /api/send from=") {
+		t.Fatalf("expected caller fingerprint log, got output %q", output)
+	}
+	if !strings.Contains(output, `user_agent="unit-test-fingerprint"`) {
+		t.Fatalf("expected user agent in caller fingerprint log, got output %q", output)
+	}
 }
 
 func TestStoreChatPreservesEphemeralSettings(t *testing.T) {

--- a/whatsapp-bridge/main_test.go
+++ b/whatsapp-bridge/main_test.go
@@ -5,12 +5,10 @@ import (
 	"database/sql"
 	"encoding/json"
 	"io"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -131,33 +129,8 @@ func newTestMessageStore(t *testing.T) *MessageStore {
 	return &MessageStore{db: db}
 }
 
-func freeTCPPort(t *testing.T) int {
-	t.Helper()
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("failed to allocate free TCP port: %v", err)
-	}
-	defer func() { _ = listener.Close() }()
-
-	_, portString, err := net.SplitHostPort(listener.Addr().String())
-	if err != nil {
-		t.Fatalf("failed to split listener address: %v", err)
-	}
-	port, err := strconv.Atoi(portString)
-	if err != nil {
-		t.Fatalf("failed to parse listener port: %v", err)
-	}
-	return port
-}
-
 func TestSendHandlerLogsCallerBeforeDecode(t *testing.T) {
 	const token = "supersecrettoken1234567890abcdef"
-	port := freeTCPPort(t)
-	oldMux := http.DefaultServeMux
-	http.DefaultServeMux = http.NewServeMux()
-	t.Cleanup(func() {
-		http.DefaultServeMux = oldMux
-	})
 
 	readPipe, writePipe, err := os.Pipe()
 	if err != nil {
@@ -165,29 +138,20 @@ func TestSendHandlerLogsCallerBeforeDecode(t *testing.T) {
 	}
 	oldStdout := os.Stdout
 	os.Stdout = writePipe
+	t.Cleanup(func() {
+		os.Stdout = oldStdout
+		_ = writePipe.Close()
+		_ = readPipe.Close()
+	})
 
-	startRESTServer(newTestClient(&mockLIDStore{}), newTestMessageStore(t), port, token, nil)
+	handler := newRESTMux(newTestClient(&mockLIDStore{}), newTestMessageStore(t), 8080, token, nil)
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:8080/api/send", strings.NewReader("{"))
+	req.RemoteAddr = "127.0.0.1:54321"
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("User-Agent", "unit-test-fingerprint")
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
 
-	client := &http.Client{Timeout: 2 * time.Second}
-	var resp *http.Response
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		req, reqErr := http.NewRequest(
-			http.MethodPost,
-			"http://127.0.0.1:"+strconv.Itoa(port)+"/api/send",
-			strings.NewReader("{"),
-		)
-		if reqErr != nil {
-			t.Fatalf("failed to create request: %v", reqErr)
-		}
-		req.Header.Set("Authorization", "Bearer "+token)
-		req.Header.Set("User-Agent", "unit-test-fingerprint")
-		resp, err = client.Do(req)
-		if err == nil {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
 	os.Stdout = oldStdout
 	_ = writePipe.Close()
 	outputBytes, readErr := io.ReadAll(readPipe)
@@ -195,12 +159,8 @@ func TestSendHandlerLogsCallerBeforeDecode(t *testing.T) {
 	if readErr != nil {
 		t.Fatalf("failed to read captured stdout: %v", readErr)
 	}
-	if err != nil {
-		t.Fatalf("request failed: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusBadRequest {
-		t.Fatalf("expected malformed body to return 400, got %d", resp.StatusCode)
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("expected malformed body to return 400, got %d", resp.Code)
 	}
 
 	output := string(outputBytes)


### PR DESCRIPTION
## Summary

- Adds caller fingerprint logging for authenticated `/api/send` requests.
- Logs remote address and user agent only.
- Does not log message bodies.
- Does not include PR #92's delete endpoints, mention support, MIME changes, or private GFV-specific comments.

## Testing

- `cd whatsapp-bridge && go test ./...`
- `cd whatsapp-bridge && go build ./...`

## Notes

- `golangci-lint` is not installed in this local environment; CI should cover Go lint.
- The local `autovault skill run code-review --repo .` wrapper failed because it misresolved the target as the skill cache instead of this git repository; no repo-native review script exists at `scripts/copilot-review.js` in this checkout.