### PR TITLE
fix(mcp): resolve bare numeric LIDs

### DIFF
--- a/whatsapp-mcp-server/main.py
+++ b/whatsapp-mcp-server/main.py
@@ -72,7 +72,7 @@ def get_contact(
     Args:
         identifier: Phone number, LID, or full JID. Examples:
                     - "12025551234" (phone number)
-                    - "184125298348272" (LID - long numeric)
+                    - "35047067385985" (LID - numeric)
                     - "12025551234@s.whatsapp.net" (phone JID)
                     - "184125298348272@lid" (LID JID)
         phone_number: Backward-compatible alias for `identifier`.
@@ -93,6 +93,7 @@ def get_contact(
         raise ValueError("identifier must be non-empty")
 
     # Detect identifier type and normalize to JID.
+    bare_numeric_digits: str | None = None
     if "@" in identifier:
         # Already a JID - use as-is
         jid = identifier
@@ -100,15 +101,11 @@ def get_contact(
     else:
         digits = "".join(c for c in identifier if c.isdigit())
         if digits:
-            # WhatsApp phone numbers are max 15 digits (E.164). Longer numeric IDs are typically LIDs.
-            # For 15-digit numbers, ambiguity exists (could be phone or LID), so we try phone first and
-            # fall back to LID if nothing is found.
-            if len(digits) > 15:
-                jid = f"{digits}@lid"
-                is_lid = True
-            else:
-                jid = f"{digits}@s.whatsapp.net"
-                is_lid = False
+            # LIDs can overlap phone-number lengths, so bare numeric inputs try phone first.
+            jid = f"{digits}@s.whatsapp.net"
+            is_lid = False
+            if identifier.isdigit():
+                bare_numeric_digits = digits
         else:
             # Non-numeric and not a JID; try as-is.
             jid = identifier
@@ -121,10 +118,8 @@ def get_contact(
 
     # Prefer chats table lookup via get_chat (works for both phone and LID contacts).
     candidates: list[tuple[str, bool]] = [(jid, is_lid)]
-    if "@" not in identifier and identifier.isdigit() and len(identifier) == 15:
-        # 15-digit numeric identifier is ambiguous (could be phone or LID).
-        # Try LID JID as a fallback if phone JID isn't found.
-        candidates.append((f"{identifier}@lid", True))
+    if bare_numeric_digits:
+        candidates.append((f"{bare_numeric_digits}@lid", True))
 
     chat = None
     for candidate_jid, candidate_is_lid in candidates:

--- a/whatsapp-mcp-server/tests/test_get_contact.py
+++ b/whatsapp-mcp-server/tests/test_get_contact.py
@@ -41,6 +41,31 @@ def test_get_contact_normalizes_lid(monkeypatch):
     assert result["resolved"] is True
 
 
+def test_get_contact_falls_back_to_lid_for_14_digit_numeric_identifier(monkeypatch):
+    calls = []
+
+    def fake_get_chat(jid: str, include_last_message: bool = True):
+        assert include_last_message is False
+        calls.append(jid)
+        if jid.endswith("@lid"):
+            return {"jid": jid, "name": "Lidia"}
+        return None
+
+    monkeypatch.setattr(mcp_main, "whatsapp_get_chat", fake_get_chat)
+    monkeypatch.setattr(mcp_main, "whatsapp_get_sender_name", lambda jid: jid)
+
+    result = mcp_main.get_contact(identifier="35047067385985")
+
+    assert calls == ["35047067385985@s.whatsapp.net", "35047067385985@lid"]
+    assert result["jid"] == "35047067385985@lid"
+    assert result["is_lid"] is True
+    assert result["phone_number"] is None
+    assert result["lid"] == "35047067385985"
+    assert result["name"] == "Lidia"
+    assert result["display_name"] == "Lidia"
+    assert result["resolved"] is True
+
+
 def test_get_contact_unresolved_falls_back_to_jid_user(monkeypatch):
     monkeypatch.setattr(mcp_main, "whatsapp_get_chat", lambda *args, **kwargs: None)
     monkeypatch.setattr(mcp_main, "whatsapp_get_sender_name", lambda jid: jid)


### PR DESCRIPTION
## Summary
- Resolve bare numeric `get_contact` identifiers as phone JIDs first, then retry as `@lid` when the phone chat does not resolve.
- Add a regression test for a 14-digit bare LID so shorter LIDs are covered.

## Root Cause
`get_contact` only added an `@lid` fallback for exactly 15-digit bare numeric identifiers, while the lower WhatsApp lookup layer already treats 12-15 digit numeric identifiers as possible LIDs.

## Breaking Changes
None.

## Validation
- `uv run pytest -v tests/test_get_contact.py`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest -v`
- `python3 .github/scripts/check_versions.py`
