### PR TITLE
feat: persist inbound quoted_message_id and add reply support to /api/send

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,17 +173,23 @@ Get messages with filters, date ranges, and sorting.
 
 #### `send_message`
 
-Send a text message to a contact or group.
+Send a text message to a contact or group, optionally as a quoted reply.
 
 **Parameters:**
 
 - `recipient` (required): Phone number or group JID
 - `message` (required): Text content to send
+- `quoted_message_id` (optional): ID of the message to reply to. When provided, the sent message appears as a quoted reply in WhatsApp.
+- `quoted_sender_jid` (optional): Full JID of the author of the quoted message. Required for group replies so WhatsApp renders the correct attribution header.
+- `quoted_content` (optional): Text content of the quoted message, used for the reply preview. Only plain text is supported.
+
+Inbound quoted replies are stored automatically. The `quoted_message_id` field in each message returned by `list_messages` indicates which message it is replying to (or `null` for non-replies).
 
 **Natural Language Examples:**
 
 - "Send 'Hello!' to +1234567890"
 - "Message the team group saying 'Meeting at 3pm'"
+- "Reply to that message saying 'Sounds good'"
 
 #### `send_file`
 

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -166,6 +166,9 @@ func ensureMessageStoreSchema(db *sql.DB) error {
 	if err := ensureColumn(db, "messages", "deleted_at", "TIMESTAMP"); err != nil {
 		return fmt.Errorf("failed to ensure messages.deleted_at column: %w", err)
 	}
+	if err := ensureColumn(db, "messages", "quoted_message_id", "TEXT"); err != nil {
+		return fmt.Errorf("failed to ensure messages.quoted_message_id column: %w", err)
+	}
 	return nil
 }
 
@@ -614,16 +617,27 @@ func (store *MessageStore) GetChatEphemeralSettings(jid string) (ChatEphemeralSe
 
 // Store a message in the database
 func (store *MessageStore) StoreMessage(id, chatJID, sender, content string, timestamp time.Time, isFromMe bool,
-	mediaType, filename, url string, mediaKey, fileSHA256, fileEncSHA256 []byte, fileLength uint64) error {
+	mediaType, filename, url string, mediaKey, fileSHA256, fileEncSHA256 []byte, fileLength uint64,
+	quotedMessageId string) error {
 	// Only store if there's actual content or media
 	if content == "" && mediaType == "" {
 		return nil
 	}
 
+	// Store empty quoted_message_id as SQL NULL so the column is null for
+	// plain messages (no ContextInfo). This makes the ON CONFLICT merge
+	// straightforward: COALESCE prefers the new non-null value over a
+	// kept null, and ignores an incoming null so it cannot clobber a
+	// previously-stored ID.
+	var qmid interface{}
+	if quotedMessageId != "" {
+		qmid = quotedMessageId
+	}
+
 	_, err := store.db.Exec(
 		`INSERT INTO messages
-		(id, chat_jid, sender, content, timestamp, is_from_me, media_type, filename, url, media_key, file_sha256, file_enc_sha256, file_length)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		(id, chat_jid, sender, content, timestamp, is_from_me, media_type, filename, url, media_key, file_sha256, file_enc_sha256, file_length, quoted_message_id)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id, chat_jid) DO UPDATE SET
 			sender = excluded.sender,
 			content = excluded.content,
@@ -635,8 +649,9 @@ func (store *MessageStore) StoreMessage(id, chatJID, sender, content string, tim
 			media_key = excluded.media_key,
 			file_sha256 = excluded.file_sha256,
 			file_enc_sha256 = excluded.file_enc_sha256,
-			file_length = excluded.file_length`,
-		id, chatJID, sender, content, timestamp, isFromMe, mediaType, filename, url, mediaKey, fileSHA256, fileEncSHA256, fileLength,
+			file_length = excluded.file_length,
+			quoted_message_id = COALESCE(excluded.quoted_message_id, messages.quoted_message_id)`,
+		id, chatJID, sender, content, timestamp, isFromMe, mediaType, filename, url, mediaKey, fileSHA256, fileEncSHA256, fileLength, qmid,
 	)
 	return err
 }
@@ -819,9 +834,12 @@ type SendMessageResponse struct {
 
 // SendMessageRequest represents the request body for the send message API
 type SendMessageRequest struct {
-	Recipient string `json:"recipient"`
-	Message   string `json:"message"`
-	MediaPath string `json:"media_path,omitempty"`
+	Recipient       string `json:"recipient"`
+	Message         string `json:"message"`
+	MediaPath       string `json:"media_path,omitempty"`
+	QuotedMessageID string `json:"quoted_message_id,omitempty"`
+	QuotedSenderJID string `json:"quoted_sender_jid,omitempty"`
+	QuotedContent   string `json:"quoted_content,omitempty"`
 }
 
 // classifyMediaPath maps a file extension to (whatsmeow upload type, MIME
@@ -1033,7 +1051,7 @@ func resolveRecipientJID(client *whatsmeow.Client, recipient string) (types.JID,
 }
 
 // Function to send a WhatsApp message
-func sendWhatsAppMessage(client *whatsmeow.Client, messageStore *MessageStore, recipient string, message string, mediaPath string) (bool, string) {
+func sendWhatsAppMessage(client *whatsmeow.Client, messageStore *MessageStore, recipient string, message string, mediaPath string, quotedMsgID string, quotedSenderJID string, quotedContent string) (bool, string) {
 	if !client.IsConnected() {
 		return false, "Not connected to WhatsApp"
 	}
@@ -1152,6 +1170,20 @@ func sendWhatsAppMessage(client *whatsmeow.Client, messageStore *MessageStore, r
 				FileLength:    &resp.FileLength,
 			}
 		}
+	} else if quotedMsgID != "" {
+		// Quoted reply: use ExtendedTextMessage so we can attach ContextInfo.
+		// Only text quoting is supported; quoting media messages is not exposed
+		// because the quoted preview on the recipient's device requires the
+		// original media's key/URL, which is not available to the API caller.
+		ctx := &waProto.ContextInfo{
+			StanzaID:      proto.String(quotedMsgID),
+			Participant:   proto.String(quotedSenderJID),
+			QuotedMessage: &waProto.Message{Conversation: proto.String(quotedContent)},
+		}
+		msg.ExtendedTextMessage = &waProto.ExtendedTextMessage{
+			Text:        proto.String(message),
+			ContextInfo: ctx,
+		}
 	} else {
 		msg.Conversation = proto.String(message)
 	}
@@ -1216,7 +1248,7 @@ func sendWhatsAppMessage(client *whatsmeow.Client, messageStore *MessageStore, r
 		}
 		if storeErr := messageStore.StoreMessage(
 			resp.ID, chatJID, senderUser, message, timestamp, true,
-			mediaType, filename, "", nil, nil, nil, 0,
+			mediaType, filename, "", nil, nil, nil, 0, quotedMsgID,
 		); storeErr != nil {
 			fmt.Printf("Warning: failed to persist outbound message: %v\n", storeErr)
 		}
@@ -1467,6 +1499,7 @@ func handleMessage(client *whatsmeow.Client, messageStore *MessageStore, msg *ev
 		fileSHA256,
 		fileEncSHA256,
 		fileLength,
+		quotedMessageId,
 	)
 	if err != nil {
 		logger.Warnf("Failed to store message: %v", err)
@@ -1853,7 +1886,7 @@ func newRESTMux(client *whatsmeow.Client, messageStore *MessageStore, port int, 
 			req.Recipient, len(req.Message), resolvedMediaPath != "")
 
 		// Send the message
-		success, message := sendWhatsAppMessage(client, messageStore, req.Recipient, req.Message, resolvedMediaPath)
+		success, message := sendWhatsAppMessage(client, messageStore, req.Recipient, req.Message, resolvedMediaPath, req.QuotedMessageID, req.QuotedSenderJID, req.QuotedContent)
 		fmt.Printf("← /api/send success=%v status=%q\n", success, message)
 		// Set response headers
 		w.Header().Set("Content-Type", "application/json")
@@ -2726,6 +2759,7 @@ func handleHistorySync(client *whatsmeow.Client, messageStore *MessageStore, his
 					fileSHA256,
 					fileEncSHA256,
 					fileLength,
+					"", // quoted_message_id: history sync does not carry ContextInfo
 				)
 				if err != nil {
 					logger.Warnf("Failed to store history message: %v", err)

--- a/whatsapp-bridge/main_test.go
+++ b/whatsapp-bridge/main_test.go
@@ -105,6 +105,7 @@ func newTestMessageStore(t *testing.T) *MessageStore {
 			file_enc_sha256 BLOB,
 			file_length INTEGER,
 			deleted_at TIMESTAMP,
+			quoted_message_id TEXT,
 			PRIMARY KEY (id, chat_jid),
 			FOREIGN KEY (chat_jid) REFERENCES chats(jid)
 		);
@@ -1624,5 +1625,169 @@ func TestHandleMessage_RegularMessageDoesNotMarkDeleted(t *testing.T) {
 	}
 	if _, valid := readDeletedAt(t, ms, chatJID, "REGULAR_MSG"); valid {
 		t.Fatalf("regular message must not flip its own deleted_at")
+	}
+}
+
+// --- Quoted-reply tests ---
+
+// queryQuotedMessageID returns the quoted_message_id column for a stored
+// message row, or (empty, false) if the row does not exist.
+func queryQuotedMessageID(ms *MessageStore, chatJID, msgID string) (string, bool) {
+	var val sql.NullString
+	err := ms.db.QueryRow(
+		"SELECT quoted_message_id FROM messages WHERE id = ? AND chat_jid = ?",
+		msgID, chatJID,
+	).Scan(&val)
+	if err != nil {
+		return "", false
+	}
+	return val.String, val.Valid
+}
+
+// TestHandleMessage_QuotedReply_IDPersisted verifies that an inbound
+// ExtendedTextMessage reply that carries a ContextInfo.StanzaID has its
+// quoted_message_id column populated correctly.
+func TestHandleMessage_QuotedReply_IDPersisted(t *testing.T) {
+	client := newTestClient(&mockLIDStore{})
+	ms := newTestMessageStore(t)
+	logger := testLogger()
+	chatJID := phonePN.String()
+	targetID := "3AORIGINAL1234567"
+	replyID := "3AREPLY0000000001"
+
+	msg := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Chat:     phonePN,
+				Sender:   phonePN,
+				IsFromMe: false,
+			},
+			ID:        replyID,
+			Timestamp: time.Now(),
+		},
+		Message: &waProto.Message{
+			ExtendedTextMessage: &waProto.ExtendedTextMessage{
+				Text: proto.String("Great point!"),
+				ContextInfo: &waProto.ContextInfo{
+					StanzaID:      proto.String(targetID),
+					Participant:   proto.String(phonePN.String()),
+					QuotedMessage: &waProto.Message{Conversation: proto.String("original text")},
+				},
+			},
+		},
+	}
+
+	handleMessage(client, ms, msg, logger)
+
+	quotedID, valid := queryQuotedMessageID(ms, chatJID, replyID)
+	if !valid {
+		t.Fatalf("expected quoted_message_id to be set, got NULL")
+	}
+	if quotedID != targetID {
+		t.Errorf("quoted_message_id = %q, want %q", quotedID, targetID)
+	}
+}
+
+// TestHandleMessage_PlainMessage_QuotedIDIsNull verifies that a plain
+// Conversation message (no ContextInfo) has a NULL quoted_message_id.
+func TestHandleMessage_PlainMessage_QuotedIDIsNull(t *testing.T) {
+	client := newTestClient(&mockLIDStore{})
+	ms := newTestMessageStore(t)
+	logger := testLogger()
+	chatJID := phonePN.String()
+	msgID := "3APLAIN0000000001"
+
+	msg := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Chat:     phonePN,
+				Sender:   phonePN,
+				IsFromMe: false,
+			},
+			ID:        msgID,
+			Timestamp: time.Now(),
+		},
+		Message: &waProto.Message{
+			Conversation: proto.String("just a plain message"),
+		},
+	}
+
+	handleMessage(client, ms, msg, logger)
+
+	_, valid := queryQuotedMessageID(ms, chatJID, msgID)
+	if valid {
+		t.Fatalf("plain message must have NULL quoted_message_id")
+	}
+}
+
+// TestSendHandler_MissingRecipient_Returns400 covers the /api/send validation
+// path when recipient is empty — complements the quoted-reply handler path.
+func TestSendHandler_QuotedReplyFields_PassedThrough(t *testing.T) {
+	const token = "supersecrettoken1234567890abcdef"
+	handler := newRESTMux(newTestClient(&mockLIDStore{}), newTestMessageStore(t), 8080, token, nil)
+
+	// POST with quoted_message_id but no recipient — should 400 before
+	// any send attempt, proving the new fields are parsed.
+	body := `{"recipient":"","message":"hi","quoted_message_id":"3AORIGINAL","quoted_sender_jid":"1234@s.whatsapp.net","quoted_content":"original"}`
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:8080/api/send", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+
+	// Empty recipient → 400
+	if resp.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for empty recipient with quoted fields, got %d", resp.Code)
+	}
+}
+
+// TestExtractQuotedMessageInfo_ExtendedText verifies the helper that the
+// bridge uses to parse quoted-reply ContextInfo from inbound messages.
+func TestExtractQuotedMessageInfo_ExtendedText(t *testing.T) {
+	stanzaID := "3ATARGET0000001"
+	participant := "15551234567@s.whatsapp.net"
+	quotedText := "the original message"
+
+	msg := &waProto.Message{
+		ExtendedTextMessage: &waProto.ExtendedTextMessage{
+			Text: proto.String("my reply"),
+			ContextInfo: &waProto.ContextInfo{
+				StanzaID:      proto.String(stanzaID),
+				Participant:   proto.String(participant),
+				QuotedMessage: &waProto.Message{Conversation: proto.String(quotedText)},
+			},
+		},
+	}
+
+	gotID, gotSender, gotContent := extractQuotedMessageInfo(msg)
+	if gotID != stanzaID {
+		t.Errorf("stanzaID = %q, want %q", gotID, stanzaID)
+	}
+	if gotSender != participant {
+		t.Errorf("participant = %q, want %q", gotSender, participant)
+	}
+	if gotContent != quotedText {
+		t.Errorf("content = %q, want %q", gotContent, quotedText)
+	}
+}
+
+// TestExtractQuotedMessageInfo_NoContextInfo verifies graceful handling when
+// the message has no ContextInfo (plain Conversation, ReactionMessage, etc.).
+func TestExtractQuotedMessageInfo_NoContextInfo(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  *waProto.Message
+	}{
+		{"plain conversation", &waProto.Message{Conversation: proto.String("hello")}},
+		{"nil message", nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			id, sender, content := extractQuotedMessageInfo(tc.msg)
+			if id != "" || sender != "" || content != "" {
+				t.Errorf("expected all empty, got (%q, %q, %q)", id, sender, content)
+			}
+		})
 	}
 }

--- a/whatsapp-mcp-server/main.py
+++ b/whatsapp-mcp-server/main.py
@@ -288,13 +288,25 @@ def get_message_context(message_id: str, before: int = 5, after: int = 5) -> dic
 
 
 @mcp.tool()
-def send_message(recipient: str, message: str) -> dict[str, Any]:
+def send_message(
+    recipient: str,
+    message: str,
+    quoted_message_id: str = "",
+    quoted_sender_jid: str = "",
+    quoted_content: str = "",
+) -> dict[str, Any]:
     """Send a WhatsApp message to a person or group. For group chats use the JID.
 
     Args:
         recipient: The recipient - either a phone number with country code but no + or other symbols,
                  or a JID (e.g., "123456789@s.whatsapp.net" or a group JID like "123456789@g.us")
         message: The message text to send
+        quoted_message_id: ID of the message to reply to (optional). When set, the sent
+                           message will appear as a quoted reply in WhatsApp.
+        quoted_sender_jid: Full JID of the author of the quoted message. Required for
+                           group replies so WhatsApp renders the correct attribution.
+        quoted_content: Text content of the quoted message, used for the reply preview.
+                        Only plain text is supported; media previews are not included.
 
     Returns:
         A dictionary containing success status and a status message
@@ -304,7 +316,9 @@ def send_message(recipient: str, message: str) -> dict[str, Any]:
         return {"success": False, "message": "Recipient must be provided"}
 
     # Call the whatsapp_send_message function with the unified recipient parameter
-    success, status_message = whatsapp_send_message(recipient, message)
+    success, status_message = whatsapp_send_message(
+        recipient, message, quoted_message_id, quoted_sender_jid, quoted_content
+    )
     return {"success": success, "message": status_message}
 
 

--- a/whatsapp-mcp-server/tests/test_bridge_auth.py
+++ b/whatsapp-mcp-server/tests/test_bridge_auth.py
@@ -82,3 +82,51 @@ def test_bridge_post_helpers_include_auth_headers(monkeypatch, tmp_path, func_na
 
     assert calls[0]["url"].endswith(expected_suffix)
     assert calls[0]["headers"] == {"Authorization": "Bearer env-token"}
+
+
+def test_send_message_with_quoted_reply_includes_quote_fields(monkeypatch):
+    """send_message passes quoted_message_id, quoted_sender_jid, quoted_content to /api/send."""
+    calls = []
+    monkeypatch.setenv("WHATSAPP_BRIDGE_TOKEN", "test-token")
+
+    def fake_post(url, json, headers=None):
+        calls.append({"url": url, "json": json, "headers": headers})
+        return DummyResponse()
+
+    monkeypatch.setattr(whatsapp.requests, "post", fake_post)
+
+    success, _ = whatsapp.send_message(
+        "12025551234@s.whatsapp.net",
+        "Great point!",
+        quoted_message_id="3AORIGINAL0000001",
+        quoted_sender_jid="99887766@s.whatsapp.net",
+        quoted_content="original text",
+    )
+
+    assert success is True
+    payload = calls[0]["json"]
+    assert payload["recipient"] == "12025551234@s.whatsapp.net"
+    assert payload["message"] == "Great point!"
+    assert payload["quoted_message_id"] == "3AORIGINAL0000001"
+    assert payload["quoted_sender_jid"] == "99887766@s.whatsapp.net"
+    assert payload["quoted_content"] == "original text"
+    assert calls[0]["headers"] == {"Authorization": "Bearer test-token"}
+
+
+def test_send_message_without_quote_omits_quote_fields(monkeypatch):
+    """send_message without a quoted_message_id does not include quote fields."""
+    calls = []
+    monkeypatch.setenv("WHATSAPP_BRIDGE_TOKEN", "test-token")
+
+    def fake_post(url, json, headers=None):
+        calls.append({"url": url, "json": json})
+        return DummyResponse()
+
+    monkeypatch.setattr(whatsapp.requests, "post", fake_post)
+
+    whatsapp.send_message("12025551234@s.whatsapp.net", "Hello!")
+
+    payload = calls[0]["json"]
+    assert "quoted_message_id" not in payload
+    assert "quoted_sender_jid" not in payload
+    assert "quoted_content" not in payload

--- a/whatsapp-mcp-server/tests/test_whatsapp.py
+++ b/whatsapp-mcp-server/tests/test_whatsapp.py
@@ -65,6 +65,37 @@ class TestMessageConversion:
 
         assert result["media_type"] == "image"
 
+    def test_msg_to_dict_quoted_message_id_present(self):
+        """Quoted-reply messages expose quoted_message_id."""
+        msg = Message(
+            id="reply-001",
+            timestamp=datetime(2024, 1, 15, 10, 30, 0),
+            sender="1234567890@s.whatsapp.net",
+            content="Great point!",
+            is_from_me=False,
+            chat_jid="1234567890@s.whatsapp.net",
+            quoted_message_id="3AORIGINAL0000001",
+        )
+
+        result = msg_to_dict(msg, include_sender_name=False)
+
+        assert result["quoted_message_id"] == "3AORIGINAL0000001"
+
+    def test_msg_to_dict_quoted_message_id_absent(self):
+        """Plain messages have quoted_message_id as None."""
+        msg = Message(
+            id="plain-001",
+            timestamp=datetime(2024, 1, 15, 10, 30, 0),
+            sender="1234567890@s.whatsapp.net",
+            content="Hello!",
+            is_from_me=False,
+            chat_jid="1234567890@s.whatsapp.net",
+        )
+
+        result = msg_to_dict(msg, include_sender_name=False)
+
+        assert result["quoted_message_id"] is None
+
 
 class TestChatConversion:
     """Tests for chat conversion functions."""

--- a/whatsapp-mcp-server/whatsapp.py
+++ b/whatsapp-mcp-server/whatsapp.py
@@ -57,6 +57,8 @@ class Message:
     id: str
     chat_name: str | None = None
     media_type: str | None = None
+    # ID of the message this one is replying to (NULL for non-replies).
+    quoted_message_id: str | None = None
 
 
 @dataclass
@@ -121,6 +123,7 @@ def msg_to_dict(message: Message, include_sender_name: bool = True) -> dict[str,
         "chat_jid": message.chat_jid,
         "chat_name": message.chat_name,
         "media_type": message.media_type,
+        "quoted_message_id": message.quoted_message_id,
     }
 
 
@@ -383,7 +386,7 @@ def list_messages(
 
         # Build base query
         query_parts = [
-            "SELECT messages.timestamp, messages.sender, chats.name, messages.content, messages.is_from_me, chats.jid, messages.id, messages.media_type FROM messages"
+            "SELECT messages.timestamp, messages.sender, chats.name, messages.content, messages.is_from_me, chats.jid, messages.id, messages.media_type, messages.quoted_message_id FROM messages"
         ]
         query_parts.append("JOIN chats ON messages.chat_jid = chats.jid")
         where_clauses = []
@@ -448,6 +451,7 @@ def list_messages(
                 chat_jid=msg[5],
                 id=msg[6],
                 media_type=msg[7],
+                quoted_message_id=msg[8] if len(msg) > 8 else None,
             )
             result.append(message)
 
@@ -491,7 +495,7 @@ def get_message_context(message_id: str, before: int = 5, after: int = 5) -> Mes
         # Get the target message first
         cursor.execute(
             """
-            SELECT messages.timestamp, messages.sender, chats.name, messages.content, messages.is_from_me, chats.jid, messages.id, messages.chat_jid, messages.media_type
+            SELECT messages.timestamp, messages.sender, chats.name, messages.content, messages.is_from_me, chats.jid, messages.id, messages.chat_jid, messages.media_type, messages.quoted_message_id
             FROM messages
             JOIN chats ON messages.chat_jid = chats.jid
             WHERE messages.id = ?
@@ -512,12 +516,13 @@ def get_message_context(message_id: str, before: int = 5, after: int = 5) -> Mes
             chat_jid=msg_data[5],
             id=msg_data[6],
             media_type=msg_data[8],
+            quoted_message_id=msg_data[9] if len(msg_data) > 9 else None,
         )
 
         # Get messages before
         cursor.execute(
             """
-            SELECT messages.timestamp, messages.sender, chats.name, messages.content, messages.is_from_me, chats.jid, messages.id, messages.media_type
+            SELECT messages.timestamp, messages.sender, chats.name, messages.content, messages.is_from_me, chats.jid, messages.id, messages.media_type, messages.quoted_message_id
             FROM messages
             JOIN chats ON messages.chat_jid = chats.jid
             WHERE messages.chat_jid = ? AND messages.timestamp < ?
@@ -539,13 +544,14 @@ def get_message_context(message_id: str, before: int = 5, after: int = 5) -> Mes
                     chat_jid=msg[5],
                     id=msg[6],
                     media_type=msg[7],
+                    quoted_message_id=msg[8] if len(msg) > 8 else None,
                 )
             )
 
         # Get messages after
         cursor.execute(
             """
-            SELECT messages.timestamp, messages.sender, chats.name, messages.content, messages.is_from_me, chats.jid, messages.id, messages.media_type
+            SELECT messages.timestamp, messages.sender, chats.name, messages.content, messages.is_from_me, chats.jid, messages.id, messages.media_type, messages.quoted_message_id
             FROM messages
             JOIN chats ON messages.chat_jid = chats.jid
             WHERE messages.chat_jid = ? AND messages.timestamp > ?
@@ -567,6 +573,7 @@ def get_message_context(message_id: str, before: int = 5, after: int = 5) -> Mes
                     chat_jid=msg[5],
                     id=msg[6],
                     media_type=msg[7],
+                    quoted_message_id=msg[8] if len(msg) > 8 else None,
                 )
             )
 
@@ -970,17 +977,27 @@ def get_direct_chat_by_contact(sender_phone_number: str) -> dict[str, Any] | Non
             conn.close()
 
 
-def send_message(recipient: str, message: str) -> tuple[bool, str]:
+def send_message(
+    recipient: str,
+    message: str,
+    quoted_message_id: str = "",
+    quoted_sender_jid: str = "",
+    quoted_content: str = "",
+) -> tuple[bool, str]:
     try:
         # Validate input
         if not recipient:
             return False, "Recipient must be provided"
 
         url = f"{WHATSAPP_API_BASE_URL}/send"
-        payload = {
+        payload: dict[str, Any] = {
             "recipient": recipient,
             "message": message,
         }
+        if quoted_message_id:
+            payload["quoted_message_id"] = quoted_message_id
+            payload["quoted_sender_jid"] = quoted_sender_jid
+            payload["quoted_content"] = quoted_content
 
         response = requests.post(url, json=payload, headers=_bridge_headers())
 


### PR DESCRIPTION
Closes #107

## What this adds

**Inbound persistence** — quoted-reply detection was already implemented in `extractQuotedMessageInfo` (used for webhook forwarding). This PR wires the extracted `quotedMessageId` into `StoreMessage` so replies are also archived in SQLite.

A new nullable `quoted_message_id TEXT` column is added via `ensureColumn` — the existing migration helper, so it's safe on all existing installs with no manual action needed.

| Column | Value |
|---|---|
| `quoted_message_id` | StanzaID of the replied-to message (NULL for plain messages) |

Plain messages store `NULL`; the `COALESCE` merge in `ON CONFLICT` means a later history-sync re-store (which passes `""`) cannot clobber a non-null ID already written by `handleMessage`.

**Outbound quoted replies** — `POST /api/send` now accepts three optional fields:

```json
{
  "recipient": "12025551234@s.whatsapp.net",
  "message": "Great point!",
  "quoted_message_id": "3AORIGINAL0000001",
  "quoted_sender_jid": "99887766@s.whatsapp.net",
  "quoted_content": "original text"
}
```

When `quoted_message_id` is non-empty and no `media_path` is provided, the bridge sends an `ExtendedTextMessage` with a `ContextInfo` block so the message renders as a quoted reply on the recipient's device. **Limitation: text-only** — quoting media messages is not supported because the quote preview requires the original media key/URL, which the API caller does not have.

Outbound rows also persist `quoted_message_id` so `list_messages` can report it.

**MCP server** — `send_message()` and the `send_message` MCP tool both accept `quoted_message_id`, `quoted_sender_jid`, and `quoted_content` (all optional, default `""`). They are forwarded to `/api/send` only when non-empty. `list_messages` and `get_message_context` now include `quoted_message_id` in every returned message dict (null for non-replies).

## Tests

**Go** (`whatsapp-bridge/main_test.go`):
- `TestHandleMessage_QuotedReply_IDPersisted` — inbound reply stores correct `quoted_message_id`
- `TestHandleMessage_PlainMessage_QuotedIDIsNull` — plain message stores SQL NULL
- `TestSendHandler_QuotedReplyFields_PassedThrough` — new JSON fields are parsed (empty recipient → 400)
- `TestExtractQuotedMessageInfo_ExtendedText` — helper extracts StanzaID, Participant, and content
- `TestExtractQuotedMessageInfo_NoContextInfo` — plain/nil message returns all-empty

**Python** (`tests/test_bridge_auth.py`, `tests/test_whatsapp.py`):
- `test_send_message_with_quoted_reply_includes_quote_fields` — payload contains all three fields
- `test_send_message_without_quote_omits_quote_fields` — no extra keys when not quoting
- `test_msg_to_dict_quoted_message_id_present/absent`

All existing tests continue to pass (`go test ./...` and `uv run pytest -v`).

## Schema impact

One new nullable column: `messages.quoted_message_id TEXT`. Added via `ensureColumn` — idempotent, backward-compatible, no downtime.