### PR TITLE
feat(bridge): add macOS launchd installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,61 @@ outbox is `~/.local/share/whatsapp-mcp/outbox`, created on bridge startup. Move
 files there before calling `send_file` or `send_audio_message`, or set
 `WHATSAPP_MEDIA_ROOTS` to a colon-separated list of absolute directories.
 
+### Run automatically on macOS
+
+macOS users can install optional per-user `launchd` jobs that start the Go
+bridge at login and monitor it every 60 seconds for API health, disconnects, and
+QR relink signals. The installer does not require `sudo` and does not install or
+start the MCP server.
+
+```bash
+scripts/install-launchd-macos.sh
+```
+
+The installer builds `whatsapp-bridge/whatsapp-bridge` with `go build` when Go is
+available, writes generated support files to
+`~/Library/Application Support/whatsapp-mcp/`, writes LaunchAgents to
+`~/Library/LaunchAgents/`, and writes logs to `~/Library/Logs/whatsapp-mcp/`.
+It safely reloads only these labels:
+
+- `com.whatsapp-mcp.bridge`
+- `com.whatsapp-mcp.bridge-monitor`
+
+To customize the launchd environment, export values before running the installer.
+Re-run the installer after changing them.
+
+```bash
+export WHATSAPP_BRIDGE_PORT=8080
+export WEBHOOK_URL=http://localhost:8769/whatsapp/webhook
+export FORWARD_SELF=false
+export WHATSAPP_MEDIA_ROOTS="$HOME/.local/share/whatsapp-mcp/outbox"
+scripts/install-launchd-macos.sh
+```
+
+Verify the jobs and inspect logs:
+
+```bash
+launchctl print gui/$(id -u)/com.whatsapp-mcp.bridge
+launchctl print gui/$(id -u)/com.whatsapp-mcp.bridge-monitor
+tail -n 100 ~/Library/Logs/whatsapp-mcp/bridge.err.log
+tail -n 100 ~/Library/Logs/whatsapp-mcp/monitor.err.log
+```
+
+The monitor sends a macOS notification once per failure type until recovery. It
+alerts when the bridge LaunchAgent is unloaded, the token is missing, the health
+endpoint is unreachable, WhatsApp is disconnected, or recent logs indicate that
+QR relinking is needed.
+
+Uninstall the generated LaunchAgents and support files with:
+
+```bash
+scripts/uninstall-launchd-macos.sh
+```
+
+Uninstall preserves `whatsapp-bridge/store/`, including WhatsApp session DBs,
+message DBs, media, and `.bridge-token`. Logs are left in
+`~/Library/Logs/whatsapp-mcp/` for manual cleanup.
+
 ### CLI flags (Go bridge)
 
 | Flag                  | Default | Description                                                                                                                                                                                                                                                       |

--- a/scripts/install-launchd-macos.sh
+++ b/scripts/install-launchd-macos.sh
@@ -180,10 +180,20 @@ if [[ -z "\$TOKEN" ]]; then
 fi
 clear_alert "token"
 
-API_URL="\${WHATSAPP_API_URL%/}"
-HEALTH="\$(curl -sS -m 5 -H "Authorization: Bearer \$TOKEN" "\$API_URL/health" 2>/dev/null || true)"
-if [[ -z "\$HEALTH" ]]; then
-  alert_once "api" "WhatsApp Bridge API Unreachable" "The health endpoint did not respond at \$API_URL/health."
+API_URL="${WHATSAPP_API_URL%/}"
+response="$(curl -sS -m 5 -H "Authorization: Bearer $TOKEN" -w $'\n%{http_code}' "$API_URL/health" 2>/dev/null || true)"
+if [[ -z "$response" ]]; then
+  alert_once "api" "WhatsApp Bridge API Unreachable" "The health endpoint did not respond at $API_URL/health."
+  exit 0
+fi
+http_code="${response##*$'\n'}"
+HEALTH="${response%$'\n'*}"
+if [[ "$http_code" == "401" || "$http_code" == "403" ]]; then
+  alert_once "token" "WhatsApp Bridge Token Invalid" "The health endpoint rejected the configured token. Re-sync WHATSAPP_BRIDGE_TOKEN or $TOKEN_FILE."
+  exit 0
+fi
+if [[ "$http_code" != "200" && "$http_code" != "503" ]]; then
+  alert_once "api" "WhatsApp Bridge API Unreachable" "Unexpected HTTP $http_code from $API_URL/health."
   exit 0
 fi
 clear_alert "api"

--- a/scripts/install-launchd-macos.sh
+++ b/scripts/install-launchd-macos.sh
@@ -1,0 +1,259 @@
+#!/bin/zsh
+set -euo pipefail
+
+BRIDGE_LABEL="com.whatsapp-mcp.bridge"
+MONITOR_LABEL="com.whatsapp-mcp.bridge-monitor"
+
+fail() {
+  print -r -- "Error: $1" >&2
+  exit 1
+}
+
+require_macos_user() {
+  [[ "$(uname -s)" == "Darwin" ]] || fail "launchd installation is only supported on macOS."
+  [[ "${EUID:-$(id -u)}" != "0" ]] || fail "Do not run this installer with sudo; it installs per-user LaunchAgents."
+}
+
+shell_quote() {
+  local value="$1"
+  printf "'"
+  printf "%s" "$value" | sed "s/'/'\\\\''/g"
+  printf "'"
+}
+
+xml_escape() {
+  printf "%s" "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g'
+}
+
+write_export() {
+  local name="$1"
+  local value="$2"
+  printf "export %s=%s\n" "$name" "$(shell_quote "$value")" >> "$ENV_FILE"
+}
+
+validate_port() {
+  local port="$1"
+  [[ "$port" =~ '^[0-9]+$' ]] || fail "WHATSAPP_BRIDGE_PORT must be a number, got: $port"
+  (( port >= 1 && port <= 65535 )) || fail "WHATSAPP_BRIDGE_PORT must be between 1 and 65535, got: $port"
+}
+
+bootout_label() {
+  local domain="$1"
+  local label="$2"
+  launchctl bootout "$domain/$label" 2>/dev/null || true
+}
+
+require_macos_user
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BRIDGE_DIR="$REPO_ROOT/whatsapp-bridge"
+BRIDGE_BINARY="$BRIDGE_DIR/whatsapp-bridge"
+
+[[ -d "$BRIDGE_DIR" ]] || fail "Could not find bridge directory: $BRIDGE_DIR"
+
+PORT="${WHATSAPP_BRIDGE_PORT:-8080}"
+validate_port "$PORT"
+API_URL="${WHATSAPP_API_URL:-http://127.0.0.1:${PORT}/api}"
+
+SUPPORT_DIR="$HOME/Library/Application Support/whatsapp-mcp"
+STATE_DIR="$SUPPORT_DIR/state"
+LOG_DIR="$HOME/Library/Logs/whatsapp-mcp"
+LAUNCH_AGENTS_DIR="$HOME/Library/LaunchAgents"
+ENV_FILE="$SUPPORT_DIR/launchd.env"
+RUNNER_SCRIPT="$SUPPORT_DIR/run-whatsapp-bridge.sh"
+MONITOR_SCRIPT="$SUPPORT_DIR/monitor-whatsapp-bridge.sh"
+BRIDGE_PLIST="$LAUNCH_AGENTS_DIR/$BRIDGE_LABEL.plist"
+MONITOR_PLIST="$LAUNCH_AGENTS_DIR/$MONITOR_LABEL.plist"
+
+USER_ID="$(id -u)"
+LAUNCHD_DOMAIN="gui/$USER_ID"
+
+mkdir -p "$SUPPORT_DIR" "$STATE_DIR" "$LOG_DIR" "$LAUNCH_AGENTS_DIR"
+
+if command -v go >/dev/null 2>&1; then
+  print -r -- "Building WhatsApp bridge..."
+  (cd "$BRIDGE_DIR" && go build -o "$BRIDGE_BINARY" .)
+elif [[ ! -x "$BRIDGE_BINARY" ]]; then
+  fail "Go is not available and no executable bridge binary exists at $BRIDGE_BINARY."
+fi
+
+[[ -x "$BRIDGE_BINARY" ]] || fail "Bridge binary is not executable: $BRIDGE_BINARY"
+
+print -r -- "Stopping existing whatsapp-mcp LaunchAgents if present..."
+bootout_label "$LAUNCHD_DOMAIN" "$MONITOR_LABEL"
+bootout_label "$LAUNCHD_DOMAIN" "$BRIDGE_LABEL"
+
+if command -v lsof >/dev/null 2>&1 && lsof -nP -iTCP:"$PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+  lsof -nP -iTCP:"$PORT" -sTCP:LISTEN >&2 || true
+  fail "Port $PORT is already in use after stopping existing whatsapp-mcp LaunchAgents."
+fi
+
+: > "$ENV_FILE"
+write_export "WHATSAPP_MCP_REPO_ROOT" "$REPO_ROOT"
+write_export "WHATSAPP_BRIDGE_DIR" "$BRIDGE_DIR"
+write_export "WHATSAPP_BRIDGE_BINARY" "$BRIDGE_BINARY"
+write_export "WHATSAPP_BRIDGE_PORT" "$PORT"
+write_export "WHATSAPP_API_URL" "$API_URL"
+write_export "WHATSAPP_MCP_LOG_DIR" "$LOG_DIR"
+write_export "WHATSAPP_MCP_STATE_DIR" "$STATE_DIR"
+
+for optional_var in WEBHOOK_URL FORWARD_SELF WHATSAPP_BRIDGE_TOKEN WHATSAPP_MEDIA_ROOTS; do
+  if [[ -v "$optional_var" ]]; then
+    write_export "$optional_var" "${(P)optional_var}"
+  fi
+done
+chmod 600 "$ENV_FILE"
+
+cat > "$RUNNER_SCRIPT" <<EOF
+#!/bin/zsh
+set -euo pipefail
+
+source $(shell_quote "$ENV_FILE")
+cd "\$WHATSAPP_BRIDGE_DIR"
+exec "\$WHATSAPP_BRIDGE_BINARY"
+EOF
+chmod 755 "$RUNNER_SCRIPT"
+
+cat > "$MONITOR_SCRIPT" <<EOF
+#!/bin/zsh
+set -euo pipefail
+
+source $(shell_quote "$ENV_FILE")
+
+BRIDGE_LABEL="$BRIDGE_LABEL"
+STATE_DIR="\${WHATSAPP_MCP_STATE_DIR:-\$HOME/Library/Application Support/whatsapp-mcp/state}"
+LOG_DIR="\${WHATSAPP_MCP_LOG_DIR:-\$HOME/Library/Logs/whatsapp-mcp}"
+TOKEN_FILE="\$WHATSAPP_BRIDGE_DIR/store/.bridge-token"
+BRIDGE_LOG="\$LOG_DIR/bridge.out.log"
+
+mkdir -p "\$STATE_DIR"
+
+notify() {
+  local title="\$1"
+  local msg="\$2"
+  if command -v terminal-notifier >/dev/null 2>&1; then
+    terminal-notifier -title "\$title" -message "\$msg" >/dev/null 2>&1 || true
+  else
+    osascript \\
+      -e 'on run argv' \\
+      -e 'display notification (item 2 of argv) with title (item 1 of argv)' \\
+      -e 'end run' \\
+      "\$title" "\$msg" >/dev/null 2>&1 || true
+  fi
+}
+
+alert_once() {
+  local key="\$1"
+  local title="\$2"
+  local msg="\$3"
+  local marker="\$STATE_DIR/\$key.alerted"
+  if [[ ! -f "\$marker" ]]; then
+    notify "\$title" "\$msg"
+    : > "\$marker"
+  fi
+}
+
+clear_alert() {
+  local key="\$1"
+  rm -f "\$STATE_DIR/\$key.alerted"
+}
+
+USER_ID="\$(id -u)"
+if ! launchctl print "gui/\$USER_ID/\$BRIDGE_LABEL" >/dev/null 2>&1; then
+  alert_once "down" "WhatsApp Bridge Down" "The bridge LaunchAgent is not loaded."
+  exit 0
+fi
+clear_alert "down"
+
+TOKEN="\${WHATSAPP_BRIDGE_TOKEN:-}"
+if [[ -z "\$TOKEN" && -r "\$TOKEN_FILE" ]]; then
+  TOKEN="\$(tr -d '[:space:]' < "\$TOKEN_FILE")"
+fi
+
+if [[ -z "\$TOKEN" ]]; then
+  alert_once "token" "WhatsApp Bridge Token Missing" "No WHATSAPP_BRIDGE_TOKEN is configured and \$TOKEN_FILE is unreadable."
+  exit 0
+fi
+clear_alert "token"
+
+API_URL="\${WHATSAPP_API_URL%/}"
+HEALTH="\$(curl -sS -m 5 -H "Authorization: Bearer \$TOKEN" "\$API_URL/health" 2>/dev/null || true)"
+if [[ -z "\$HEALTH" ]]; then
+  alert_once "api" "WhatsApp Bridge API Unreachable" "The health endpoint did not respond at \$API_URL/health."
+  exit 0
+fi
+clear_alert "api"
+
+connected=false
+if print -r -- "\$HEALTH" | grep -Eq '"connected"[[:space:]]*:[[:space:]]*true'; then
+  connected=true
+fi
+
+if [[ "\$connected" == "true" ]]; then
+  clear_alert "relink"
+  clear_alert "qr"
+else
+  alert_once "relink" "WhatsApp Relink Needed" "The bridge is running but WhatsApp is disconnected. Check logs and scan a QR code if prompted."
+  if [[ -f "\$BRIDGE_LOG" ]]; then
+    if tail -n 200 "\$BRIDGE_LOG" 2>/dev/null | grep -Eiq 'Scan this QR code|Device logged out|QR code timed out|Timeout waiting for QR code scan'; then
+      alert_once "qr" "WhatsApp QR Action Needed" "The bridge logs indicate that phone linking is required."
+    else
+      clear_alert "qr"
+    fi
+  fi
+fi
+EOF
+chmod 755 "$MONITOR_SCRIPT"
+
+cat > "$BRIDGE_PLIST" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key><string>$BRIDGE_LABEL</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>$(xml_escape "$RUNNER_SCRIPT")</string>
+    </array>
+    <key>WorkingDirectory</key><string>$(xml_escape "$BRIDGE_DIR")</string>
+    <key>RunAtLoad</key><true/>
+    <key>KeepAlive</key><true/>
+    <key>ThrottleInterval</key><integer>10</integer>
+    <key>StandardOutPath</key><string>$(xml_escape "$LOG_DIR/bridge.out.log")</string>
+    <key>StandardErrorPath</key><string>$(xml_escape "$LOG_DIR/bridge.err.log")</string>
+  </dict>
+</plist>
+EOF
+
+cat > "$MONITOR_PLIST" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key><string>$MONITOR_LABEL</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>$(xml_escape "$MONITOR_SCRIPT")</string>
+    </array>
+    <key>RunAtLoad</key><true/>
+    <key>StartInterval</key><integer>60</integer>
+    <key>StandardOutPath</key><string>$(xml_escape "$LOG_DIR/monitor.out.log")</string>
+    <key>StandardErrorPath</key><string>$(xml_escape "$LOG_DIR/monitor.err.log")</string>
+  </dict>
+</plist>
+EOF
+
+print -r -- "Loading whatsapp-mcp LaunchAgents..."
+launchctl bootstrap "$LAUNCHD_DOMAIN" "$BRIDGE_PLIST"
+launchctl enable "$LAUNCHD_DOMAIN/$BRIDGE_LABEL"
+launchctl kickstart -k "$LAUNCHD_DOMAIN/$BRIDGE_LABEL"
+
+launchctl bootstrap "$LAUNCHD_DOMAIN" "$MONITOR_PLIST"
+launchctl enable "$LAUNCHD_DOMAIN/$MONITOR_LABEL"
+launchctl kickstart -k "$LAUNCHD_DOMAIN/$MONITOR_LABEL"
+
+print -r -- "Installed whatsapp-mcp LaunchAgents:"
+print -r -- "  $BRIDGE_LABEL"
+print -r -- "  $MONITOR_LABEL"
+print -r -- "Logs: $LOG_DIR"

--- a/scripts/install-launchd-macos.sh
+++ b/scripts/install-launchd-macos.sh
@@ -89,7 +89,10 @@ if command -v lsof >/dev/null 2>&1 && lsof -nP -iTCP:"$PORT" -sTCP:LISTEN >/dev/
   fail "Port $PORT is already in use after stopping existing whatsapp-mcp LaunchAgents."
 fi
 
+old_umask="$(umask)"
+umask 077
 : > "$ENV_FILE"
+umask "$old_umask"
 write_export "WHATSAPP_MCP_REPO_ROOT" "$REPO_ROOT"
 write_export "WHATSAPP_BRIDGE_DIR" "$BRIDGE_DIR"
 write_export "WHATSAPP_BRIDGE_BINARY" "$BRIDGE_BINARY"

--- a/scripts/tests/test-launchd-macos.sh
+++ b/scripts/tests/test-launchd-macos.sh
@@ -1,0 +1,285 @@
+#!/bin/zsh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+GREP_BIN="$(command -v grep)"
+WC_BIN="$(command -v wc)"
+TR_BIN="$(command -v tr)"
+
+failures=0
+
+fail() {
+  print -r -- "FAIL: $1" >&2
+  failures=$((failures + 1))
+}
+
+assert_file() {
+  local path="$1"
+  [[ -f "$path" ]] || fail "expected file: $path"
+}
+
+assert_executable() {
+  local path="$1"
+  [[ -x "$path" ]] || fail "expected executable: $path"
+}
+
+assert_dir() {
+  local path="$1"
+  [[ -d "$path" ]] || fail "expected directory: $path"
+}
+
+assert_not_exists() {
+  local path="$1"
+  [[ ! -e "$path" ]] || fail "expected path to be removed: $path"
+}
+
+assert_contains() {
+  local path="$1"
+  local needle="$2"
+  if ! "$GREP_BIN" -Fq -- "$needle" "$path"; then
+    fail "expected $path to contain: $needle"
+  fi
+}
+
+assert_line_count() {
+  local path="$1"
+  local expected="$2"
+  local actual=0
+  if [[ -f "$path" ]]; then
+    actual="$("$WC_BIN" -l < "$path" | "$TR_BIN" -d '[:space:]')"
+  fi
+  [[ "$actual" == "$expected" ]] || fail "expected $path to have $expected lines, got $actual"
+}
+
+make_fixture() {
+  local tmp
+  tmp="$(mktemp -d "${TMPDIR:-/tmp}/whatsapp-mcp-launchd-test.XXXXXX")"
+  mkdir -p "$tmp/repo/scripts" "$tmp/repo/whatsapp-bridge/store" "$tmp/home" "$tmp/fakebin"
+
+  cp "$REPO_ROOT/scripts/install-launchd-macos.sh" "$tmp/repo/scripts/"
+  cp "$REPO_ROOT/scripts/uninstall-launchd-macos.sh" "$tmp/repo/scripts/"
+
+  cat > "$tmp/fakebin/uname" <<'EOF'
+#!/bin/sh
+printf 'Darwin\n'
+EOF
+
+  cat > "$tmp/fakebin/id" <<'EOF'
+#!/bin/sh
+if [ "$1" = "-u" ]; then
+  printf '501\n'
+  exit 0
+fi
+/usr/bin/id "$@"
+EOF
+
+  cat > "$tmp/fakebin/go" <<'EOF'
+#!/bin/sh
+printf 'go %s\n' "$*" >> "$FAKE_CMD_LOG"
+out=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    shift
+    out="$1"
+  fi
+  shift || true
+done
+if [ -n "$out" ]; then
+  mkdir -p "$(dirname "$out")"
+  printf '#!/bin/sh\nexit 0\n' > "$out"
+  chmod +x "$out"
+fi
+exit 0
+EOF
+
+  cat > "$tmp/fakebin/lsof" <<'EOF'
+#!/bin/sh
+printf 'lsof %s\n' "$*" >> "$FAKE_CMD_LOG"
+if [ "${FAKE_LSOF_BUSY:-0}" = "1" ]; then
+  printf 'whatsapp 123 user 10u IPv4 TCP 127.0.0.1:8080 (LISTEN)\n'
+  exit 0
+fi
+exit 1
+EOF
+
+  cat > "$tmp/fakebin/launchctl" <<'EOF'
+#!/bin/sh
+printf 'launchctl %s\n' "$*" >> "$FAKE_CMD_LOG"
+if [ "${1:-}" = "print" ] && [ "${FAKE_LAUNCHCTL_PRINT_FAIL:-0}" = "1" ]; then
+  exit 1
+fi
+exit 0
+EOF
+
+  cat > "$tmp/fakebin/curl" <<'EOF'
+#!/bin/sh
+printf 'curl %s\n' "$*" >> "$FAKE_CMD_LOG"
+if [ "${FAKE_CURL_EMPTY:-0}" = "1" ]; then
+  exit 7
+fi
+printf '%s\n' "${FAKE_CURL_RESPONSE:-{\"status\":\"ok\",\"connected\":true}}"
+exit "${FAKE_CURL_EXIT:-0}"
+EOF
+
+  cat > "$tmp/fakebin/osascript" <<'EOF'
+#!/bin/sh
+printf 'osascript %s\n' "$*" >> "$FAKE_NOTIFY_LOG"
+exit 0
+EOF
+
+  chmod +x "$tmp/fakebin/"*
+  print -r -- "$tmp"
+}
+
+run_installer() {
+  local tmp="$1"
+  (
+    cd "$tmp/repo"
+    HOME="$tmp/home" \
+    PATH="$tmp/fakebin:/usr/bin:/bin" \
+    FAKE_CMD_LOG="$tmp/cmd.log" \
+    ./scripts/install-launchd-macos.sh
+  )
+}
+
+run_uninstaller() {
+  local tmp="$1"
+  (
+    cd "$tmp/repo"
+    HOME="$tmp/home" \
+    PATH="$tmp/fakebin:/usr/bin:/bin" \
+    FAKE_CMD_LOG="$tmp/cmd.log" \
+    ./scripts/uninstall-launchd-macos.sh
+  )
+}
+
+run_monitor() {
+  local tmp="$1"
+  local response="$2"
+  HOME="$tmp/home" \
+  PATH="$tmp/fakebin:/usr/bin:/bin" \
+  FAKE_CMD_LOG="$tmp/cmd.log" \
+  FAKE_NOTIFY_LOG="$tmp/notify.log" \
+  FAKE_CURL_RESPONSE="$response" \
+  "$tmp/home/Library/Application Support/whatsapp-mcp/monitor-whatsapp-bridge.sh"
+}
+
+test_install_generates_launchd_files() {
+  local tmp support launch_agents logs repo
+  tmp="$(make_fixture)"
+  repo="$(cd "$tmp/repo" && pwd)"
+  run_installer "$tmp"
+
+  support="$tmp/home/Library/Application Support/whatsapp-mcp"
+  launch_agents="$tmp/home/Library/LaunchAgents"
+  logs="$tmp/home/Library/Logs/whatsapp-mcp"
+
+  assert_dir "$support"
+  assert_dir "$logs"
+  assert_executable "$support/run-whatsapp-bridge.sh"
+  assert_executable "$support/monitor-whatsapp-bridge.sh"
+  assert_file "$support/launchd.env"
+  assert_file "$launch_agents/com.whatsapp-mcp.bridge.plist"
+  assert_file "$launch_agents/com.whatsapp-mcp.bridge-monitor.plist"
+
+  assert_contains "$support/launchd.env" "export WHATSAPP_BRIDGE_PORT='8080'"
+  assert_contains "$support/launchd.env" "export WHATSAPP_API_URL='http://127.0.0.1:8080/api'"
+  assert_contains "$support/launchd.env" "export WHATSAPP_MCP_REPO_ROOT='$repo'"
+  assert_contains "$support/launchd.env" "export WHATSAPP_BRIDGE_DIR='$repo/whatsapp-bridge'"
+  assert_contains "$support/launchd.env" "export WHATSAPP_BRIDGE_BINARY='$repo/whatsapp-bridge/whatsapp-bridge'"
+
+  assert_contains "$launch_agents/com.whatsapp-mcp.bridge.plist" "com.whatsapp-mcp.bridge"
+  assert_contains "$launch_agents/com.whatsapp-mcp.bridge.plist" "$support/run-whatsapp-bridge.sh"
+  assert_contains "$launch_agents/com.whatsapp-mcp.bridge.plist" "$logs/bridge.out.log"
+  assert_contains "$launch_agents/com.whatsapp-mcp.bridge-monitor.plist" "com.whatsapp-mcp.bridge-monitor"
+  assert_contains "$launch_agents/com.whatsapp-mcp.bridge-monitor.plist" "$support/monitor-whatsapp-bridge.sh"
+  assert_contains "$launch_agents/com.whatsapp-mcp.bridge-monitor.plist" "<key>StartInterval</key><integer>60</integer>"
+
+  assert_contains "$tmp/cmd.log" "go build -o $repo/whatsapp-bridge/whatsapp-bridge ."
+  assert_contains "$tmp/cmd.log" "launchctl bootout gui/501/com.whatsapp-mcp.bridge"
+  assert_contains "$tmp/cmd.log" "launchctl bootstrap gui/501 $launch_agents/com.whatsapp-mcp.bridge.plist"
+  assert_contains "$tmp/cmd.log" "launchctl kickstart -k gui/501/com.whatsapp-mcp.bridge-monitor"
+}
+
+test_install_preserves_optional_env_values() {
+  local tmp support
+  tmp="$(make_fixture)"
+  (
+    cd "$tmp/repo"
+    HOME="$tmp/home" \
+    PATH="$tmp/fakebin:/usr/bin:/bin" \
+    FAKE_CMD_LOG="$tmp/cmd.log" \
+    WHATSAPP_BRIDGE_PORT="9090" \
+    WEBHOOK_URL="http://127.0.0.1:8769/whatsapp/webhook" \
+    FORWARD_SELF="true" \
+    WHATSAPP_BRIDGE_TOKEN="test token with spaces" \
+    WHATSAPP_MEDIA_ROOTS="/tmp/outbox:/tmp/other outbox" \
+    ./scripts/install-launchd-macos.sh
+  )
+
+  support="$tmp/home/Library/Application Support/whatsapp-mcp"
+  assert_contains "$support/launchd.env" "export WHATSAPP_BRIDGE_PORT='9090'"
+  assert_contains "$support/launchd.env" "export WHATSAPP_API_URL='http://127.0.0.1:9090/api'"
+  assert_contains "$support/launchd.env" "export WEBHOOK_URL='http://127.0.0.1:8769/whatsapp/webhook'"
+  assert_contains "$support/launchd.env" "export FORWARD_SELF='true'"
+  assert_contains "$support/launchd.env" "export WHATSAPP_BRIDGE_TOKEN='test token with spaces'"
+  assert_contains "$support/launchd.env" "export WHATSAPP_MEDIA_ROOTS='/tmp/outbox:/tmp/other outbox'"
+}
+
+test_uninstall_removes_generated_files_only() {
+  local tmp support launch_agents logs
+  tmp="$(make_fixture)"
+  run_installer "$tmp"
+
+  support="$tmp/home/Library/Application Support/whatsapp-mcp"
+  launch_agents="$tmp/home/Library/LaunchAgents"
+  logs="$tmp/home/Library/Logs/whatsapp-mcp"
+  print -r -- "db" > "$tmp/repo/whatsapp-bridge/store/messages.db"
+  print -r -- "log" > "$logs/bridge.out.log"
+
+  run_uninstaller "$tmp"
+
+  assert_not_exists "$launch_agents/com.whatsapp-mcp.bridge.plist"
+  assert_not_exists "$launch_agents/com.whatsapp-mcp.bridge-monitor.plist"
+  assert_not_exists "$support"
+  assert_file "$tmp/repo/whatsapp-bridge/store/messages.db"
+  assert_file "$logs/bridge.out.log"
+  assert_contains "$tmp/cmd.log" "launchctl bootout gui/501/com.whatsapp-mcp.bridge"
+  assert_contains "$tmp/cmd.log" "launchctl bootout gui/501/com.whatsapp-mcp.bridge-monitor"
+}
+
+test_monitor_alerts_once_and_clears_on_recovery() {
+  local tmp support state
+  tmp="$(make_fixture)"
+  run_installer "$tmp"
+  support="$tmp/home/Library/Application Support/whatsapp-mcp"
+  state="$support/state"
+  print -r -- "token-1234567890123456" > "$tmp/repo/whatsapp-bridge/store/.bridge-token"
+
+  run_monitor "$tmp" '{"status":"disconnected","connected":false}'
+  run_monitor "$tmp" '{"status":"disconnected","connected":false}'
+  assert_line_count "$tmp/notify.log" 1
+  assert_file "$state/relink.alerted"
+
+  run_monitor "$tmp" '{"status":"ok","connected":true}'
+  assert_line_count "$tmp/notify.log" 1
+  assert_not_exists "$state/relink.alerted"
+}
+
+for test_name in \
+  test_install_generates_launchd_files \
+  test_install_preserves_optional_env_values \
+  test_uninstall_removes_generated_files_only \
+  test_monitor_alerts_once_and_clears_on_recovery
+do
+  print -r -- "Running $test_name"
+  "$test_name"
+done
+
+if (( failures > 0 )); then
+  print -r -- "$failures test failure(s)" >&2
+  exit 1
+fi
+
+print -r -- "All launchd script tests passed"

--- a/scripts/uninstall-launchd-macos.sh
+++ b/scripts/uninstall-launchd-macos.sh
@@ -1,0 +1,40 @@
+#!/bin/zsh
+set -euo pipefail
+
+BRIDGE_LABEL="com.whatsapp-mcp.bridge"
+MONITOR_LABEL="com.whatsapp-mcp.bridge-monitor"
+
+fail() {
+  print -r -- "Error: $1" >&2
+  exit 1
+}
+
+[[ "$(uname -s)" == "Darwin" ]] || fail "launchd uninstall is only supported on macOS."
+[[ "${EUID:-$(id -u)}" != "0" ]] || fail "Do not run this uninstaller with sudo; it removes per-user LaunchAgents."
+
+SUPPORT_DIR="$HOME/Library/Application Support/whatsapp-mcp"
+LOG_DIR="$HOME/Library/Logs/whatsapp-mcp"
+LAUNCH_AGENTS_DIR="$HOME/Library/LaunchAgents"
+BRIDGE_PLIST="$LAUNCH_AGENTS_DIR/$BRIDGE_LABEL.plist"
+MONITOR_PLIST="$LAUNCH_AGENTS_DIR/$MONITOR_LABEL.plist"
+LAUNCHD_DOMAIN="gui/$(id -u)"
+
+bootout_label() {
+  local label="$1"
+  launchctl bootout "$LAUNCHD_DOMAIN/$label" 2>/dev/null || true
+}
+
+print -r -- "Stopping whatsapp-mcp LaunchAgents if present..."
+bootout_label "$MONITOR_LABEL"
+bootout_label "$BRIDGE_LABEL"
+
+rm -f "$BRIDGE_PLIST" "$MONITOR_PLIST"
+rm -f "$SUPPORT_DIR/run-whatsapp-bridge.sh"
+rm -f "$SUPPORT_DIR/monitor-whatsapp-bridge.sh"
+rm -f "$SUPPORT_DIR/launchd.env"
+rm -rf "$SUPPORT_DIR/state"
+rmdir "$SUPPORT_DIR" 2>/dev/null || true
+
+print -r -- "Removed whatsapp-mcp LaunchAgents and generated support files."
+print -r -- "Preserved bridge data under whatsapp-bridge/store/."
+print -r -- "Logs were left in place: $LOG_DIR"


### PR DESCRIPTION
## Summary

- add optional per-user macOS launchd installer/uninstaller scripts for the Go bridge
- add a generated monitor job that checks authenticated /api/health, token availability, disconnected state, and QR/relink log signals
- document install, verification, customization, logs, and uninstall flow

Closes #115

## Tests

- zsh -n scripts/install-launchd-macos.sh && zsh -n scripts/uninstall-launchd-macos.sh && zsh -n scripts/tests/test-launchd-macos.sh
- zsh scripts/tests/test-launchd-macos.sh
- cd whatsapp-bridge && go test ./...

## Local acceptance

Validated on Jack's macOS checkout by installing both LaunchAgents, confirming authenticated /api/health returned connected=true, uninstalling and verifying generated files were removed while whatsapp-bridge/store/ stayed intact, then reinstalling and leaving the bridge + monitor jobs loaded.