### PR TITLE
docs(readme): document app state recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,7 +586,9 @@ are documented in [docs/RELEASING.md](docs/RELEASING.md).
 - **QR Code Not Displaying**: Restart the bridge. Check terminal QR code support.
 - **Device Limit Reached**: Remove a linked device from WhatsApp Settings > Linked Devices.
 - **No Messages Loading**: Initial sync can take several minutes for large chat histories.
-- **Out of Sync**: Delete `whatsapp-bridge/store/*.db` files and re-authenticate.
+- **Out of Sync**: Back up `whatsapp-bridge/store`, then move
+  `whatsapp-bridge/store/whatsapp.db` aside and re-authenticate. Keep
+  `messages.db` unless you intentionally want to discard local message history.
 - **Bridge returns 401 Unauthorized**: Restart the bridge so it creates
   `whatsapp-bridge/store/.bridge-token`, then restart the MCP server. If the MCP
   server cannot read that file, set `WHATSAPP_BRIDGE_TOKEN` to the same value in
@@ -597,6 +599,44 @@ are documented in [docs/RELEASING.md](docs/RELEASING.md).
 - **Bridge returns 403 Forbidden for media_path**: Move the file into
   `~/.local/share/whatsapp-mcp/outbox` or add its absolute parent directory to
   `WHATSAPP_MEDIA_ROOTS`.
+
+### App State / LTHash Conflicts
+
+Some WhatsApp account state is managed by whatsmeow in
+`whatsapp-bridge/store/whatsapp.db`. If the bridge reports errors like:
+
+```text
+SendAppState failed: server returned error updating app state (regular_low):
+<error code="409" text="conflict"/>
+failed to verify patch v12345: mismatching LTHash
+```
+
+then WhatsApp's app-state patch chain for the linked device is out of sync.
+This usually affects operations that write chat settings such as archive,
+mute, or pin state. Incoming and outgoing messages may still work because
+message storage lives separately in `messages.db`.
+
+Known manual resync attempts such as `FetchAppState(..., fullSync=true)` may
+still fail on this upstream app-state error class. The practical recovery path
+is to reset the whatsmeow session and re-pair:
+
+```bash
+# Stop the bridge first.
+launchctl bootout gui/$UID/com.whatsapp-bridge    # or however you manage it
+
+# Back up the whole runtime store.
+cp -a whatsapp-bridge/store whatsapp-bridge/store.bak.$(date +%Y%m%d%H%M%S)
+
+# Reset only the whatsmeow session/app-state DB.
+mv whatsapp-bridge/store/whatsapp.db whatsapp-bridge/store/whatsapp.db.lthash.bak
+
+# Restart the bridge and scan the new QR code.
+cd whatsapp-bridge
+go run .
+```
+
+Do not remove `whatsapp-bridge/store/messages.db` for this recovery unless you
+also want to delete the local message archive.
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ whatsmeow's default pairing asks for "recent sync" — roughly the last 3 months
 
 ```bash
 # Stop the bridge
-launchctl bootout gui/$UID/com.whatsapp-bridge    # or however you manage it
+launchctl bootout gui/$UID/com.whatsapp-mcp.bridge    # or however you manage it
 
 # Back up, then remove the auth session (keeps messages.db intact)
 cp whatsapp-bridge/store/whatsapp.db{,.bak}
@@ -622,7 +622,7 @@ is to reset the whatsmeow session and re-pair:
 
 ```bash
 # Stop the bridge first.
-launchctl bootout gui/$UID/com.whatsapp-bridge    # or however you manage it
+launchctl bootout gui/$UID/com.whatsapp-mcp.bridge    # or however you manage it
 
 # Back up the whole runtime store.
 cp -a whatsapp-bridge/store whatsapp-bridge/store.bak.$(date +%Y%m%d%H%M%S)
@@ -632,7 +632,7 @@ mv whatsapp-bridge/store/whatsapp.db whatsapp-bridge/store/whatsapp.db.lthash.ba
 
 # Restart the bridge and scan the new QR code.
 cd whatsapp-bridge
-go run .
+./whatsapp-bridge    # or `go run .` during development
 ```
 
 Do not remove `whatsapp-bridge/store/messages.db` for this recovery unless you


### PR DESCRIPTION
## Summary
- document LTHash/app-state conflict symptoms and recovery path
- narrow the generic out-of-sync guidance to reset only `whatsapp.db`
- keep `messages.db` preserved unless users intentionally want to discard local history

## Tests
- `git diff --check origin/main..HEAD`

## Risk
- Docs-only change; no runtime behavior changes.

Refs #111