### PR TITLE
fix(mcp): serialize message context result

### DIFF
--- a/whatsapp-mcp-server/main.py
+++ b/whatsapp-mcp-server/main.py
@@ -32,6 +32,9 @@ from whatsapp import (
     list_messages as whatsapp_list_messages,
 )
 from whatsapp import (
+    msg_to_dict,
+)
+from whatsapp import (
     search_contacts as whatsapp_search_contacts,
 )
 from whatsapp import (
@@ -284,7 +287,11 @@ def get_message_context(message_id: str, before: int = 5, after: int = 5) -> dic
         after: Number of messages to include after the target message (default 5)
     """
     context = whatsapp_get_message_context(message_id, before, after)
-    return context
+    return {
+        "message": msg_to_dict(context.message),
+        "before": [msg_to_dict(message) for message in context.before],
+        "after": [msg_to_dict(message) for message in context.after],
+    }
 
 
 @mcp.tool()

--- a/whatsapp-mcp-server/tests/test_message_context_tool.py
+++ b/whatsapp-mcp-server/tests/test_message_context_tool.py
@@ -1,0 +1,50 @@
+from datetime import datetime
+
+import main
+from whatsapp import Message, MessageContext
+
+
+def test_get_message_context_serializes_dataclass(monkeypatch):
+    target = Message(
+        id="target",
+        timestamp=datetime(2024, 1, 15, 10, 30, 0),
+        sender="12025550100@s.whatsapp.net",
+        content="target message",
+        is_from_me=False,
+        chat_jid="12025550100@s.whatsapp.net",
+        chat_name="Test Chat",
+    )
+    before = Message(
+        id="before",
+        timestamp=datetime(2024, 1, 15, 10, 29, 0),
+        sender="12025550100@s.whatsapp.net",
+        content="before message",
+        is_from_me=False,
+        chat_jid="12025550100@s.whatsapp.net",
+        chat_name="Test Chat",
+    )
+    after = Message(
+        id="after",
+        timestamp=datetime(2024, 1, 15, 10, 31, 0),
+        sender="me@s.whatsapp.net",
+        content="after message",
+        is_from_me=True,
+        chat_jid="12025550100@s.whatsapp.net",
+        chat_name="Test Chat",
+    )
+
+    monkeypatch.setattr(
+        main,
+        "whatsapp_get_message_context",
+        lambda message_id, before_count, after_count: MessageContext(
+            message=target,
+            before=[before],
+            after=[after],
+        ),
+    )
+
+    result = main.get_message_context("target", before=1, after=1)
+
+    assert result["message"]["id"] == "target"
+    assert result["before"][0]["id"] == "before"
+    assert result["after"][0]["id"] == "after"


### PR DESCRIPTION
## Summary

- Serialize the `MessageContext` dataclass returned by the data layer before returning from the MCP `get_message_context` tool.
- Add regression coverage for the tool returning `message`, `before`, and `after` dictionaries.

Closes #73

## Tests

- `cd whatsapp-mcp-server && uv lock --check`
- `cd whatsapp-mcp-server && uv run --extra dev pytest -v`
- `cd whatsapp-mcp-server && uv run --extra dev ruff check . && uv run --extra dev ruff format --check .`