### PR TITLE
fix(mcp): deduplicate contact chat results

### DIFF
--- a/whatsapp-mcp-server/tests/test_list_chats.py
+++ b/whatsapp-mcp-server/tests/test_list_chats.py
@@ -125,3 +125,52 @@ def test_get_chat_without_last_message(messages_db):
 def test_get_chat_missing_jid_returns_none(messages_db):
     assert whatsapp.get_chat("nonexistent@s.whatsapp.net") is None
     assert whatsapp.get_chat("nonexistent@s.whatsapp.net", include_last_message=False) is None
+
+
+def test_get_contact_chats_returns_each_chat_once_with_last_message(messages_db):
+    conn = sqlite3.connect(messages_db)
+    cursor = conn.cursor()
+    cursor.execute(
+        "INSERT INTO chats (jid, name, last_message_time) VALUES (?, ?, ?)",
+        ("group-1@g.us", "Group", "2024-01-15 10:40:00+00:00"),
+    )
+    cursor.executemany(
+        """INSERT INTO messages
+           (id, chat_jid, sender, content, timestamp, is_from_me)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        [
+            (
+                "group-msg-1",
+                "group-1@g.us",
+                "1234567890@s.whatsapp.net",
+                "contact's earlier group message",
+                "2024-01-15 10:35:00+00:00",
+                0,
+            ),
+            (
+                "group-msg-2",
+                "group-1@g.us",
+                "1234567890@s.whatsapp.net",
+                "contact's later group message",
+                "2024-01-15 10:36:00+00:00",
+                0,
+            ),
+            (
+                "group-last",
+                "group-1@g.us",
+                "9999999999@s.whatsapp.net",
+                "actual chat last message",
+                "2024-01-15 10:40:00+00:00",
+                0,
+            ),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    chats = whatsapp.get_contact_chats("1234567890@s.whatsapp.net")
+    group_chats = [chat for chat in chats if chat["jid"] == "group-1@g.us"]
+
+    assert len(group_chats) == 1
+    assert group_chats[0]["last_message"] == "actual chat last message"
+    assert group_chats[0]["last_sender"] == "9999999999@s.whatsapp.net"

--- a/whatsapp-mcp-server/whatsapp.py
+++ b/whatsapp-mcp-server/whatsapp.py
@@ -774,12 +774,18 @@ def get_contact_chats(jid: str, limit: int = 20, page: int = 0) -> list[dict[str
                 c.jid,
                 c.name,
                 c.last_message_time,
-                m.content as last_message,
-                m.sender as last_sender,
-                m.is_from_me as last_is_from_me
+                last_msg.content as last_message,
+                last_msg.sender as last_sender,
+                last_msg.is_from_me as last_is_from_me
             FROM chats c
-            JOIN messages m ON c.jid = m.chat_jid
-            WHERE m.sender IN ({placeholders}) OR c.jid = ?
+            LEFT JOIN messages last_msg ON c.jid = last_msg.chat_jid
+                AND c.last_message_time = last_msg.timestamp
+            WHERE EXISTS (
+                SELECT 1
+                FROM messages contact_msg
+                WHERE contact_msg.chat_jid = c.jid
+                    AND contact_msg.sender IN ({placeholders})
+            ) OR c.jid = ?
             ORDER BY c.last_message_time DESC
             LIMIT ? OFFSET ?
         """,


### PR DESCRIPTION
## Summary

- Make `get_contact_chats` filter chats by contact participation without using the matching messages as display rows.
- Join the chat last message separately so each chat appears once with its actual last-message fields.
- Add regression coverage for duplicate group-chat rows.

Closes #74

## Tests

- `cd whatsapp-mcp-server && uv lock --check`
- `cd whatsapp-mcp-server && uv run --extra dev pytest -v`
- `cd whatsapp-mcp-server && uv run --extra dev ruff check . && uv run --extra dev ruff format --check .`