### PR TITLE
docs(readme): add demo video overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ A Model Context Protocol (MCP) server for WhatsApp, enabling Claude to read and 
 
 > Originally created by [Luke Harries](https://github.com/lharries/whatsapp-mcp). Maintained by [Very Good Plugins](https://verygoodplugins.com/?utm_source=github).
 
+<p align="center">
+  <a href="https://github.com/user-attachments/assets/9475af1d-2369-4315-9ccc-823dba2c5c32"><strong>Watch the WhatsApp MCP demo video</strong></a>
+</p>
+
+<p align="center">
+  <sub>Product demo generated with Remotion using simulated data.</sub>
+</p>
+
 ## Features
 
 - **Message Management**: Search and read personal WhatsApp messages (text, images, videos, documents, audio)


### PR DESCRIPTION
## Summary
- Add the approved Remotion README demo video embed near the top of the README
- Include a simulated-data caption below the video

## Tests
- `git diff --check -- README.md`
- `curl -L -r 0-1023` against the GitHub user-attachments URL returned `206 video/mp4`
- `file` confirmed the ranged probe is MP4 base media
- Added-line leak scan returned no matches

## Risk
- Docs-only change; generated video is hosted through GitHub user-attachments and anchored by closed issue #121.