### PR TITLE
fix: escape monitor-script shell vars in launchd installer

### DIFF
--- a/scripts/install-launchd-macos.sh
+++ b/scripts/install-launchd-macos.sh
@@ -180,20 +180,20 @@ if [[ -z "\$TOKEN" ]]; then
 fi
 clear_alert "token"
 
-API_URL="${WHATSAPP_API_URL%/}"
-response="$(curl -sS -m 5 -H "Authorization: Bearer $TOKEN" -w $'\n%{http_code}' "$API_URL/health" 2>/dev/null || true)"
-if [[ -z "$response" ]]; then
-  alert_once "api" "WhatsApp Bridge API Unreachable" "The health endpoint did not respond at $API_URL/health."
+API_URL="\${WHATSAPP_API_URL%/}"
+response="\$(curl -sS -m 5 -H "Authorization: Bearer \$TOKEN" -w \$'\n%{http_code}' "\$API_URL/health" 2>/dev/null || true)"
+if [[ -z "\$response" ]]; then
+  alert_once "api" "WhatsApp Bridge API Unreachable" "The health endpoint did not respond at \$API_URL/health."
   exit 0
 fi
-http_code="${response##*$'\n'}"
-HEALTH="${response%$'\n'*}"
-if [[ "$http_code" == "401" || "$http_code" == "403" ]]; then
-  alert_once "token" "WhatsApp Bridge Token Invalid" "The health endpoint rejected the configured token. Re-sync WHATSAPP_BRIDGE_TOKEN or $TOKEN_FILE."
+http_code="\${response##*\$'\n'}"
+HEALTH="\${response%\$'\n'*}"
+if [[ "\$http_code" == "401" || "\$http_code" == "403" ]]; then
+  alert_once "token" "WhatsApp Bridge Token Invalid" "The health endpoint rejected the configured token. Re-sync WHATSAPP_BRIDGE_TOKEN or \$TOKEN_FILE."
   exit 0
 fi
-if [[ "$http_code" != "200" && "$http_code" != "503" ]]; then
-  alert_once "api" "WhatsApp Bridge API Unreachable" "Unexpected HTTP $http_code from $API_URL/health."
+if [[ "\$http_code" != "200" && "\$http_code" != "503" ]]; then
+  alert_once "api" "WhatsApp Bridge API Unreachable" "Unexpected HTTP \$http_code from \$API_URL/health."
   exit 0
 fi
 clear_alert "api"


### PR DESCRIPTION
## Problem

`scripts/install-launchd-macos.sh` aborts for any user who does not already have certain variables exported in their shell:

```
install-launchd-macos.sh:121: WHATSAPP_API_URL: parameter not set
```

The installer builds the monitor script via an **unquoted** here-doc (`cat > "$MONITOR_SCRIPT" <<EOF`) under `set -euo pipefail`. Most of the monitor body correctly escapes its runtime variables as `\$`, but the health-check block (lines ~183–199) used bare `$` for `WHATSAPP_API_URL`, `TOKEN`, `response`, `http_code`, `HEALTH`, etc. Those bare references are expanded at **install time** instead of being written literally into the generated monitor script; under `set -u` the first unset one (`WHATSAPP_API_URL` — the script only sets a local `API_URL`, never exports `WHATSAPP_API_URL`) terminates the installer before the LaunchAgents are written.

## Fix

Escape the affected `$` references (`\$`) so they are emitted verbatim into `monitor-whatsapp-bridge.sh` and evaluated at **monitor runtime**, where the sourced env file and the curl response provide them — matching the already-escaped lines elsewhere in the same here-doc.

## Testing

- `zsh -n scripts/install-launchd-macos.sh` parses cleanly.
- Ran the installer end-to-end on macOS (Apple zsh): both `com.whatsapp-mcp.bridge` and `com.whatsapp-mcp.bridge-monitor` LaunchAgents install and load; bridge reports `{"connected":true}`; the generated monitor script contains the correctly-escaped runtime variables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)