### PR TITLE
fix(bridge): keep CDN auth tokens in directPath to fix 403 media downloads

### DIFF
--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -1830,13 +1830,10 @@ func extractDirectPathFromURL(url string) string {
 		return url // Return original URL if parsing fails
 	}
 
-	pathPart := parts[1]
-
-	// Remove query parameters
-	pathPart = strings.SplitN(pathPart, "?", 2)[0]
-
-	// Create proper direct path format
-	return "/" + pathPart
+	// Keep the query string: it carries the CDN auth tokens (oh=/oe=).
+	// whatsmeow's Download rebuilds the URL as host + directPath + "&hash=..."
+	// and the CDN returns 403 if the auth params are missing.
+	return "/" + parts[1]
 }
 
 // Start a REST API server to expose the WhatsApp client functionality.

--- a/whatsapp-bridge/main_test.go
+++ b/whatsapp-bridge/main_test.go
@@ -131,6 +131,39 @@ func newTestMessageStore(t *testing.T) *MessageStore {
 	return &MessageStore{db: db}
 }
 
+func TestExtractDirectPathFromURL(t *testing.T) {
+	cases := []struct {
+		name                   string
+		input                  string
+		want                   string
+		requireSingleSlashPath bool
+	}{
+		{
+			name:                   "preserves WhatsApp CDN auth query",
+			input:                  "https://mmg.whatsapp.net/v/t62.7118-24/13812002_698058036224062_3424455886509161511_n.enc?ccb=11-4&oh=01_Q5Aa&oe=6854A1B2",
+			want:                   "/v/t62.7118-24/13812002_698058036224062_3424455886509161511_n.enc?ccb=11-4&oh=01_Q5Aa&oe=6854A1B2",
+			requireSingleSlashPath: true,
+		},
+		{
+			name:  "keeps fallback for URLs without WhatsApp CDN marker",
+			input: "https://example.com/v/t62.7118-24/file.enc?ccb=11-4&oh=01_Q5Aa&oe=6854A1B2",
+			want:  "https://example.com/v/t62.7118-24/file.enc?ccb=11-4&oh=01_Q5Aa&oe=6854A1B2",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractDirectPathFromURL(tc.input)
+			if got != tc.want {
+				t.Fatalf("extractDirectPathFromURL(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+			if tc.requireSingleSlashPath && (!strings.HasPrefix(got, "/") || strings.HasPrefix(got, "//")) {
+				t.Fatalf("expected exactly one leading slash in %q", got)
+			}
+		})
+	}
+}
+
 func TestSendHandlerLogsCallerBeforeDecode(t *testing.T) {
 	const token = "supersecrettoken1234567890abcdef"
 


### PR DESCRIPTION
## Problem

All media downloads through the bridge fail with `403` from WhatsApp's CDN:

```
{"success":false,"message":"Failed to download media: failed to download media: download failed with status code 403"}
```

This affects every media message, including ones received seconds earlier, so it is not URL expiry.

## Cause

Recent whatsmeow versions (including the `20260604` build currently in `go.mod`) no longer use `GetURL()` in `Download()`. They require `GetDirectPath()` and rebuild the download URL themselves:

```go
mediaURL := fmt.Sprintf("https://%s%s&hash=%s&mms-type=%s&__wa-mms=", host.Hostname, directPath, ...)
```

The WhatsApp CDN authenticates requests via the `oh=`/`oe=` query parameters that are part of the direct path. `extractDirectPathFromURL()` strips the query string, so every rebuilt URL goes out without its auth token → `403`.

This worked before because older whatsmeow used the full stored URL directly when present.

## Fix

Keep the query string when extracting the direct path. Note this also makes the rebuilt URL well-formed: whatsmeow appends `&hash=...`, which assumes the direct path already contains a `?`.

The `oe=` parameter is the CDN expiry (~1 month), so still-valid media downloads correctly again, and genuinely expired media keeps failing exactly as before.

## Testing

- Reproduced the 403 on a live bridge (Team mode, macOS) for fresh voice notes
- With this patch: same messages download successfully; ran a 149-message audio backfill where all non-expired items (13) downloaded and the rest failed only due to genuine `oe=` expiry

🤖 Generated with [Claude Code](https://claude.com/claude-code)
