### PR TITLE
fix(server): resolve .bridge-token from WHATSMEOW_DB_PATH for containerized deploys

### DIFF
--- a/whatsapp-mcp-server/tests/test_bridge_token_path.py
+++ b/whatsapp-mcp-server/tests/test_bridge_token_path.py
@@ -1,0 +1,23 @@
+import os
+
+import whatsapp
+
+
+def test_bridge_token_path_colocated_with_whatsmeow_db():
+    """The token file lives in the same store dir as whatsapp.db, so relocating
+    the data directory (e.g. into a Docker volume) keeps bridge auth working."""
+    assert os.path.dirname(whatsapp._BRIDGE_TOKEN_PATH) == os.path.dirname(
+        whatsapp.WHATSMEOW_DB_PATH
+    )
+
+
+def test_read_bridge_token_reads_from_relocated_store(monkeypatch, tmp_path):
+    """When WHATSMEOW_DB_PATH points at a relocated store, the token is read from
+    that same directory (regression for HTTP 401 in containerized deploys)."""
+    store = tmp_path / "store"
+    store.mkdir()
+    (store / ".bridge-token").write_text("vol-token\n", encoding="utf-8")
+    monkeypatch.setattr(whatsapp, "WHATSMEOW_DB_PATH", str(store / "whatsapp.db"))
+    monkeypatch.setattr(whatsapp, "_BRIDGE_TOKEN_PATH", str(store / ".bridge-token"))
+    monkeypatch.delenv("WHATSAPP_BRIDGE_TOKEN", raising=False)
+    assert whatsapp._read_bridge_token() == "vol-token"

--- a/whatsapp-mcp-server/whatsapp.py
+++ b/whatsapp-mcp-server/whatsapp.py
@@ -21,9 +21,13 @@ WHATSMEOW_DB_PATH = os.getenv(
 )
 WHATSAPP_API_BASE_URL = os.getenv("WHATSAPP_API_URL", "http://localhost:8080/api")
 
-_BRIDGE_TOKEN_PATH = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), "..", "whatsapp-bridge", "store", ".bridge-token"
-)
+# .bridge-token is written by the Go bridge into the same store directory as
+# whatsapp.db. Deriving it from WHATSMEOW_DB_PATH keeps it correct when the data
+# directory is relocated (e.g. a Docker volume): a path resolved relative to
+# __file__ then points outside the volume, so the MCP gets HTTP 401 from the
+# bridge on every download_media / send_* call. Falls back to the default layout
+# when WHATSMEOW_DB_PATH is unset, so non-containerized installs are unaffected.
+_BRIDGE_TOKEN_PATH = os.path.join(os.path.dirname(WHATSMEOW_DB_PATH), ".bridge-token")
 
 
 def _read_bridge_token() -> str | None:


### PR DESCRIPTION
## Summary

- `_BRIDGE_TOKEN_PATH` was resolved relative to `__file__`, so containerized deploys (data in a mounted volume) never found the `.bridge-token` the bridge writes into the relocated store → `download_media` / `send_*` got **HTTP 401** while SQLite-only tools kept working.
- Derive the token path from the directory of `WHATSMEOW_DB_PATH` (where the bridge writes both `whatsapp.db` and `.bridge-token`), with a fallback to the current default when `WHATSMEOW_DB_PATH` is unset.

## Type of change

- [x] `fix` — bug fix
- [ ] `feat` — new feature
- [ ] `chore` / `docs` / `ci` / `refactor` / `test` / `perf`
- [ ] Breaking change

## Scope check

- [x] One concern (the token-path resolution)
- [x] PR is ≤ ~300 LOC

## Linked issues

Closes #142

## Testing

- [x] Added a regression test (`tests/test_bridge_token_path.py`)
- [x] Ran `uv run pytest` — `tests/test_bridge_token_path.py` + `tests/test_bridge_auth.py` pass (17 passed)
- [x] Manually exercised the affected path: in a containerized deploy (data on a mounted volume, `WHATSMEOW_DB_PATH=/data/store/whatsapp.db`), `download_media` went from HTTP 401 to success after this change.

## Docs

- [ ] No user-visible/env changes (behavior is unchanged for default layouts; only honors the already-documented `WHATSMEOW_DB_PATH` for token location).

## Risk / rollback

Low. The change is a no-op for default (non-containerized) installs because the fallback reproduces the previous `__file__`-relative path. Revert is a single-line change.