### PR TITLE
fix(mcp): resolve bridge token from whatsmeow db path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,9 +12,10 @@ WEBHOOK_URL=http://localhost:8769/whatsapp/webhook
 FORWARD_SELF=false
 
 # Bearer token used to authenticate REST callers. The bridge generates one
-# automatically at first start and writes it to whatsapp-bridge/store/.bridge-token
-# (mode 0600). Override here to inject a token from the outside (e.g. from a
-# secret store in a container) instead of mounting the file.
+# automatically at first start and writes it to .bridge-token in the active
+# bridge store directory (mode 0600). The MCP server falls back to .bridge-token
+# next to WHATSMEOW_DB_PATH. Override here to inject a token from the outside
+# (e.g. from a secret store in a container) instead of mounting the file.
 # WHATSAPP_BRIDGE_TOKEN=
 
 # Colon-separated absolute paths that /api/send may read media files from.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,7 @@ A failing blocking job is a hard block — fix it or explain in the PR why it's 
 | `WHATSMEOW_DB_PATH` | `../whatsapp-bridge/store/whatsapp.db` | whatsmeow SQLite (LID ↔ phone resolution via `whatsmeow_lid_map`) |
 | `WHATSAPP_API_URL` | `http://localhost:8080/api` | Bridge REST endpoint |
 | `WHATSAPP_BRIDGE_PORT` | `8080` | Port the bridge binds to |
-| `WHATSAPP_BRIDGE_TOKEN` | generated in `whatsapp-bridge/store/.bridge-token` | Bearer token required for bridge REST calls |
+| `WHATSAPP_BRIDGE_TOKEN` | generated next to `WHATSMEOW_DB_PATH` as `.bridge-token` | Bearer token required for bridge REST calls |
 | `WHATSAPP_MEDIA_ROOTS` | `~/.local/share/whatsapp-mcp/outbox` | Path-list of directories allowed for outbound media files |
 | `WHATSAPP_MCP_TRANSPORT` | `stdio` | MCP transport to serve clients: `stdio`, `http`, or `sse` |
 | `WHATSAPP_MCP_HOST` | `127.0.0.1` | Bind address for the `http`/`sse` transports |

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ Copy `.env.example` to `.env` and configure as needed:
 | `WHATSAPP_DB_PATH`     | `../whatsapp-bridge/store/messages.db`   | Path to SQLite database                      |
 | `WHATSMEOW_DB_PATH`    | `../whatsapp-bridge/store/whatsapp.db`   | whatsmeow DB used for LID ↔ phone resolution |
 | `WHATSAPP_API_URL`     | `http://localhost:8080/api`              | Go bridge REST API URL                       |
-| `WHATSAPP_BRIDGE_TOKEN` | generated in `whatsapp-bridge/store/.bridge-token` | Bearer token required for bridge REST calls |
+| `WHATSAPP_BRIDGE_TOKEN` | generated next to `WHATSMEOW_DB_PATH` as `.bridge-token` | Bearer token required for bridge REST calls |
 | `WHATSAPP_MEDIA_ROOTS` | `~/.local/share/whatsapp-mcp/outbox`     | Path-list of directories allowed for outbound media files |
 | `WHATSAPP_MCP_TRANSPORT` | `stdio`                                | MCP transport to serve clients: `stdio`, `http`, or `sse` |
 | `WHATSAPP_MCP_HOST`    | `127.0.0.1`                              | Bind address for the `http`/`sse` transports |
@@ -371,10 +371,11 @@ accepts only exact loopback Host headers for its configured port. This protects
 the local REST API from other local processes and browser DNS-rebinding attacks.
 
 On first start, the bridge generates a 256-bit token, writes it to
-`whatsapp-bridge/store/.bridge-token` with owner-only permissions, and prints a
-setup banner. The MCP server reads `WHATSAPP_BRIDGE_TOKEN` first, then falls
-back to that token file. For split deployments, containers, or process managers
-that do not share the repository directory, set the same
+`.bridge-token` in the active bridge store directory with owner-only
+permissions, and prints a setup banner. The MCP server reads
+`WHATSAPP_BRIDGE_TOKEN` first, then falls back to `.bridge-token` in the same
+directory as `WHATSMEOW_DB_PATH`. For split deployments, containers, or process
+managers that do not share the store directory, set the same
 `WHATSAPP_BRIDGE_TOKEN` value for both the bridge and MCP server.
 
 Outbound `media_path` values are confined to `WHATSAPP_MEDIA_ROOTS`. The default
@@ -661,9 +662,9 @@ are documented in [docs/RELEASING.md](docs/RELEASING.md).
   `whatsapp-bridge/store/whatsapp.db` aside and re-authenticate. Keep
   `messages.db` unless you intentionally want to discard local message history.
 - **Bridge returns 401 Unauthorized**: Restart the bridge so it creates
-  `whatsapp-bridge/store/.bridge-token`, then restart the MCP server. If the MCP
-  server cannot read that file, set `WHATSAPP_BRIDGE_TOKEN` to the same value in
-  both environments.
+  `.bridge-token` next to `WHATSMEOW_DB_PATH`, then restart the MCP server. If
+  the MCP server cannot read that file, set `WHATSAPP_BRIDGE_TOKEN` to the same
+  value in both environments.
 - **Bridge returns 403 Forbidden for Host**: Use `WHATSAPP_API_URL` with
   `http://127.0.0.1:<port>/api`, `http://localhost:<port>/api`, or
   `http://[::1]:<port>/api`; custom hostnames and missing ports are rejected.

--- a/whatsapp-mcp-server/tests/test_bridge_auth.py
+++ b/whatsapp-mcp-server/tests/test_bridge_auth.py
@@ -1,3 +1,5 @@
+import importlib
+
 import pytest
 
 import whatsapp
@@ -26,6 +28,22 @@ def test_bridge_headers_falls_back_to_token_file(monkeypatch, tmp_path):
     monkeypatch.setattr(whatsapp, "_BRIDGE_TOKEN_PATH", str(token_file))
 
     assert whatsapp._bridge_headers() == {"Authorization": "Bearer file-token"}
+
+
+def test_bridge_headers_reads_token_next_to_whatsmeow_db_path(monkeypatch, tmp_path):
+    store_dir = tmp_path / "store"
+    store_dir.mkdir()
+    (store_dir / ".bridge-token").write_text("volume-token\n", encoding="utf-8")
+
+    monkeypatch.delenv("WHATSAPP_BRIDGE_TOKEN", raising=False)
+    monkeypatch.setenv("WHATSMEOW_DB_PATH", str(store_dir / "whatsapp.db"))
+
+    try:
+        importlib.reload(whatsapp)
+        assert whatsapp._bridge_headers() == {"Authorization": "Bearer volume-token"}
+    finally:
+        monkeypatch.delenv("WHATSMEOW_DB_PATH", raising=False)
+        importlib.reload(whatsapp)
 
 
 def test_bridge_headers_prefers_env_over_token_file(monkeypatch, tmp_path):

--- a/whatsapp-mcp-server/whatsapp.py
+++ b/whatsapp-mcp-server/whatsapp.py
@@ -11,19 +11,18 @@ import requests
 import audio
 
 # Configuration via environment variables with sensible defaults
+_DEFAULT_BRIDGE_STORE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "whatsapp-bridge", "store")
 MESSAGES_DB_PATH = os.getenv(
     "WHATSAPP_DB_PATH",
-    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "whatsapp-bridge", "store", "messages.db"),
+    os.path.join(_DEFAULT_BRIDGE_STORE_DIR, "messages.db"),
 )
 WHATSMEOW_DB_PATH = os.getenv(
     "WHATSMEOW_DB_PATH",
-    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "whatsapp-bridge", "store", "whatsapp.db"),
+    os.path.join(_DEFAULT_BRIDGE_STORE_DIR, "whatsapp.db"),
 )
 WHATSAPP_API_BASE_URL = os.getenv("WHATSAPP_API_URL", "http://localhost:8080/api")
 
-_BRIDGE_TOKEN_PATH = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), "..", "whatsapp-bridge", "store", ".bridge-token"
-)
+_BRIDGE_TOKEN_PATH = os.path.join(os.path.dirname(WHATSMEOW_DB_PATH), ".bridge-token")
 
 
 def _read_bridge_token() -> str | None:


### PR DESCRIPTION
## Summary
- derive the `.bridge-token` fallback from the directory containing `WHATSMEOW_DB_PATH`
- preserve `WHATSAPP_BRIDGE_TOKEN` precedence and the default local checkout behavior
- add regression coverage for mounted-store/container token lookup
- update docs to describe the token fallback path

## Breaking Changes
None.

Closes #142

## Test Plan
- `cd whatsapp-mcp-server && uv sync --extra dev`
- `cd whatsapp-mcp-server && uv run pytest -v`
- `cd whatsapp-mcp-server && uv run ruff check .`
- `cd whatsapp-mcp-server && uv run ruff format --check .`
- `git diff --check`