### PR TITLE
fix(bridge): preserve original timestamp on retry-redelivered messages

### DIFF
--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -17,6 +17,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -1525,6 +1526,52 @@ func senderAltForMessage(client *whatsmeow.Client, info types.MessageInfo) types
 }
 
 // Handle regular incoming messages with media support
+// origMsgTime remembers the true send-time of messages that first arrived
+// undecryptable (e.g. after an offline gap, when our session lacked the sender
+// key). WhatsApp re-sends such messages after a retry receipt, but the re-sent
+// copy carries a fresh `t` (the resend time) rather than the original send time.
+// The first (undecryptable) delivery *does* carry the original `t`, so we cache
+// it here and reuse it when the decrypted retry finally lands — otherwise those
+// messages get stored with reconnect-time and corrupt recency ordering.
+var (
+	origMsgTimeMu sync.Mutex
+	origMsgTime   = make(map[string]time.Time)
+)
+
+// rememberOriginalTimestamp records the earliest timestamp seen for a message ID.
+// A resend's `t` is always >= the original, so the earliest is the true one.
+func rememberOriginalTimestamp(id string, ts time.Time) {
+	if id == "" || ts.IsZero() {
+		return
+	}
+	origMsgTimeMu.Lock()
+	defer origMsgTimeMu.Unlock()
+	if existing, ok := origMsgTime[id]; !ok || ts.Before(existing) {
+		origMsgTime[id] = ts
+	}
+	// Soft cap so a burst of never-retried undecryptable messages can't grow this
+	// map unbounded. Entries are normally consumed on successful decrypt.
+	if len(origMsgTime) > 5000 {
+		for k := range origMsgTime {
+			delete(origMsgTime, k)
+			if len(origMsgTime) <= 4000 {
+				break
+			}
+		}
+	}
+}
+
+// takeOriginalTimestamp returns and removes the cached original timestamp for id.
+func takeOriginalTimestamp(id string) (time.Time, bool) {
+	origMsgTimeMu.Lock()
+	defer origMsgTimeMu.Unlock()
+	ts, ok := origMsgTime[id]
+	if ok {
+		delete(origMsgTime, id)
+	}
+	return ts, ok
+}
+
 func handleMessage(client *whatsmeow.Client, messageStore *MessageStore, msg *events.Message, logger waLog.Logger) {
 	// Resolve LID-based chats to phone-based JIDs so that incoming
 	// and outgoing messages land in the same chat entry.
@@ -1550,8 +1597,18 @@ func handleMessage(client *whatsmeow.Client, messageStore *MessageStore, msg *ev
 		}
 	}
 
+	// Recover the true send-time if this message first arrived undecryptable and is
+	// now landing via a retry-resend (whose stanza `t` is the resend time, not the
+	// original). See origMsgTime / rememberOriginalTimestamp.
+	msgTimestamp := msg.Info.Timestamp
+	if orig, ok := takeOriginalTimestamp(msg.Info.ID); ok && orig.Before(msgTimestamp) {
+		logger.Infof("Using original pre-retry timestamp for %s: %s (resend `t` was %s)",
+			msg.Info.ID, orig.Format(time.RFC3339), msgTimestamp.Format(time.RFC3339))
+		msgTimestamp = orig
+	}
+
 	// Update chat in database with the message timestamp (keeps last message time updated)
-	err := messageStore.StoreChat(chatJID, name, msg.Info.Timestamp)
+	err := messageStore.StoreChat(chatJID, name, msgTimestamp)
 	if err != nil {
 		logger.Warnf("Failed to store chat: %v", err)
 	}
@@ -1585,7 +1642,7 @@ func handleMessage(client *whatsmeow.Client, messageStore *MessageStore, msg *ev
 			emoji := reaction.GetText()
 			if err := messageStore.StoreMessage(
 				msg.Info.ID, chatJID, sender, emoji,
-				msg.Info.Timestamp, msg.Info.IsFromMe,
+				msgTimestamp, msg.Info.IsFromMe,
 				"reaction", reactedToID, "", nil, nil, nil, 0, "",
 			); err != nil {
 				logger.Warnf("Failed to store reaction: %v", err)
@@ -1618,7 +1675,7 @@ func handleMessage(client *whatsmeow.Client, messageStore *MessageStore, msg *ev
 		chatJID,
 		sender,
 		content,
-		msg.Info.Timestamp,
+		msgTimestamp,
 		msg.Info.IsFromMe,
 		mediaType,
 		filename,
@@ -2352,6 +2409,12 @@ func main() {
 		case *events.Message:
 			// Process regular messages
 			handleMessage(client, messageStore, v, logger)
+
+		case *events.UndecryptableMessage:
+			// The first (failed) delivery carries the original send-time. WhatsApp
+			// re-sends after our retry receipt, but that copy's `t` is the resend
+			// time — so stash the original now and reuse it in handleMessage.
+			rememberOriginalTimestamp(v.Info.ID, v.Info.Timestamp)
 
 		case *events.HistorySync:
 			// Process history sync events

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -1657,8 +1657,10 @@ func handleMessage(client *whatsmeow.Client, messageStore *MessageStore, msg *ev
 	// Extract text content
 	content := extractTextContent(msg.Message)
 
-	// Extract media info - pass message timestamp + ID for unique filenames
-	mediaType, filename, url, mediaKey, fileSHA256, fileEncSHA256, fileLength := extractMediaInfo(msg.Message, msg.Info.Timestamp, msg.Info.ID)
+	// Extract media info - pass message timestamp + ID for unique filenames.
+	// Must be the same (retry-corrected) timestamp we store below: downloadMedia
+	// rebuilds the on-disk filename from the stored timestamp.
+	mediaType, filename, url, mediaKey, fileSHA256, fileEncSHA256, fileLength := extractMediaInfo(msg.Message, msgTimestamp, msg.Info.ID)
 
 	// Extract quoted message info
 	quotedMessageId, quotedSender, quotedContent := extractQuotedMessageInfo(msg.Message)

--- a/whatsapp-bridge/retry_timestamp_test.go
+++ b/whatsapp-bridge/retry_timestamp_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// resetOrigMsgTime clears the package-level cache between tests.
+func resetOrigMsgTime() {
+	origMsgTimeMu.Lock()
+	defer origMsgTimeMu.Unlock()
+	origMsgTime = make(map[string]time.Time)
+}
+
+func TestRememberAndTakeOriginalTimestamp(t *testing.T) {
+	resetOrigMsgTime()
+
+	orig := time.Date(2026, 1, 2, 15, 4, 5, 0, time.UTC)
+	rememberOriginalTimestamp("MSG_A", orig)
+
+	got, ok := takeOriginalTimestamp("MSG_A")
+	if !ok {
+		t.Fatal("expected cached timestamp for MSG_A")
+	}
+	if !got.Equal(orig) {
+		t.Fatalf("got %s, want %s", got, orig)
+	}
+
+	// A message ID is consumed on take: a second take must miss.
+	if _, ok := takeOriginalTimestamp("MSG_A"); ok {
+		t.Fatal("expected MSG_A to be consumed after take")
+	}
+}
+
+func TestRememberKeepsEarliest(t *testing.T) {
+	resetOrigMsgTime()
+
+	earliest := time.Date(2026, 1, 2, 15, 4, 5, 0, time.UTC)
+	later := earliest.Add(12 * time.Hour) // e.g. the retry-resend time
+
+	// Order of observation must not matter: the earliest (original) always wins.
+	rememberOriginalTimestamp("MSG_B", later)
+	rememberOriginalTimestamp("MSG_B", earliest)
+	rememberOriginalTimestamp("MSG_B", later)
+
+	got, ok := takeOriginalTimestamp("MSG_B")
+	if !ok {
+		t.Fatal("expected cached timestamp for MSG_B")
+	}
+	if !got.Equal(earliest) {
+		t.Fatalf("got %s, want earliest %s", got, earliest)
+	}
+}
+
+func TestRememberIgnoresEmptyInput(t *testing.T) {
+	resetOrigMsgTime()
+
+	rememberOriginalTimestamp("", time.Now())       // empty ID
+	rememberOriginalTimestamp("MSG_C", time.Time{}) // zero time
+
+	if _, ok := takeOriginalTimestamp(""); ok {
+		t.Fatal("empty ID should never be cached")
+	}
+	if _, ok := takeOriginalTimestamp("MSG_C"); ok {
+		t.Fatal("zero timestamp should never be cached")
+	}
+}
+
+func TestTakeMissingReturnsFalse(t *testing.T) {
+	resetOrigMsgTime()
+	if _, ok := takeOriginalTimestamp("does-not-exist"); ok {
+		t.Fatal("expected miss for unknown ID")
+	}
+}


### PR DESCRIPTION
## Summary

- Incoming messages that fail to decrypt on first delivery (common after the bridge has been offline a while — an outage, or the periodic linked-device session expiry, when the local Signal session lacks the current sender key) are re-sent by WhatsApp after a retry receipt. The re-sent stanza's `t` is the **resend time**, not the original send time, so those messages were stored at reconnect-time — corrupting recency-ordered views (last-message-per-chat and chat sort order) until they aged out.
- Fix: cache the original timestamp from `events.UndecryptableMessage` (the first delivery carries the true `t`) and reuse it when the decrypted retry lands in `handleMessage`. Guarded to only override when strictly earlier; entries consumed on use with a soft size cap. Applied to the content and reaction store paths and the chat's last-message time.

## Type of change

- [x] `fix` — bug fix

## Scope check

- [x] This change fits the `ROADMAP.md` "in scope" list (reliability fix for the Go bridge — reconnect/session-recovery correctness)
- [x] PR is focused on one concern
- [x] PR is ≤ ~300 LOC (~140)

## Linked issues

<!-- none -->

## Testing

- [x] Added or updated tests — unit tests for the timestamp-cache helpers (earliest-wins, consume-on-take, empty/zero guards)
- [x] Ran `golangci-lint run` and `go build ./...` (Go changes) — `go build ./...`, `go vet ./...`, `gofmt`, and `go test ./...` all clean locally (golangci-lint deferred to CI)
- [x] Manually exercised the affected code path — reproduced after a multi-week offline gap: several incoming messages that failed initial decryption were stored with the reconnect time; with this change the cached original timestamp is used instead (the bridge logs `Using original pre-retry timestamp for <id>…` when it fires)

## Docs

- No user-visible surface or env/tool/schema change — internal timestamp-correctness fix, no docs update needed.

## Risk / rollback

- Low. The cache only ever *lowers* a message's timestamp toward its true send time, and only when an earlier value was observed for that exact message ID; otherwise behavior is unchanged. Memory is bounded (consumed on use + soft cap). Revert is a single commit.
