### PR TITLE
fix(bridge): authenticate outbound webhook POSTs with bridge token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,17 +5,24 @@
 WHATSAPP_BRIDGE_PORT=8080
 
 # Webhook URL for incoming messages (optional)
-# Set this to forward incoming WhatsApp messages to another service
+# Set this to forward incoming WhatsApp messages to another service. The bridge
+# authenticates every outbound webhook POST with the same bridge token it uses
+# for inbound REST auth, sent as "Authorization: Bearer <WHATSAPP_BRIDGE_TOKEN>"
+# (only when a token is configured). The receiving service must expect that same
+# token — see WHATSAPP_BRIDGE_TOKEN below.
 WEBHOOK_URL=http://localhost:8769/whatsapp/webhook
 
 # Forward messages sent by self (true/false)
 FORWARD_SELF=false
 
-# Bearer token used to authenticate REST callers. The bridge generates one
-# automatically at first start and writes it to .bridge-token in the active
-# bridge store directory (mode 0600). The MCP server falls back to .bridge-token
-# next to WHATSMEOW_DB_PATH. Override here to inject a token from the outside
-# (e.g. from a secret store in a container) instead of mounting the file.
+# Bearer token used to authenticate REST callers AND signed onto every outbound
+# webhook POST (see WEBHOOK_URL above). The bridge generates one automatically at
+# first start and writes it to .bridge-token in the active bridge store directory
+# (mode 0600). The MCP server falls back to .bridge-token next to
+# WHATSMEOW_DB_PATH. Override here to inject a token from the outside (e.g. from a
+# secret store in a container) instead of mounting the file. If your webhook
+# receiver enforces this token (e.g. the AutoHub hub's WHATSAPP_BRIDGE_TOKEN), it
+# must be set to this exact value or inbound forwarding will be rejected.
 # WHATSAPP_BRIDGE_TOKEN=
 
 # Colon-separated absolute paths that /api/send may read media files from.

--- a/.env.example
+++ b/.env.example
@@ -5,14 +5,19 @@
 WHATSAPP_BRIDGE_PORT=8080
 
 # Webhook URL for incoming messages (optional)
-# Set this to forward incoming WhatsApp messages to another service. The bridge
-# authenticates every outbound webhook POST with the same bridge token it uses
-# for inbound REST auth, sent as an "X-Bridge-Token: <WHATSAPP_BRIDGE_TOKEN>"
-# header (only when a token is configured). A dedicated header is used instead
-# of Authorization so it never collides with a receiver's own Authorization-based
-# auth (e.g. HTTP Basic auth embedded in this URL as http://user:pass@host/...).
-# The receiving service must expect that same token — see WHATSAPP_BRIDGE_TOKEN
-# below.
+# Set this to forward incoming WhatsApp messages to another service. Once set,
+# the bridge authenticates every outbound webhook POST with the same bridge
+# token it uses for inbound REST auth, sent as an
+# "X-Bridge-Token: <WHATSAPP_BRIDGE_TOKEN>" header. A dedicated header is used
+# instead of Authorization so it never collides with a receiver's own
+# Authorization-based auth (e.g. HTTP Basic auth embedded in this URL as
+# http://user:pass@host/...). The token is ONLY sent when this variable is
+# explicitly set — never to the built-in localhost default below — since the
+# same token also authorizes /api/* calls like sending messages, and nothing
+# has vetted whatever process might be listening on an unconfigured default.
+# Redirects are never followed, so a misconfigured or malicious endpoint can't
+# redirect the token to a different host. The receiving service must expect
+# that same token — see WHATSAPP_BRIDGE_TOKEN below.
 WEBHOOK_URL=http://localhost:8769/whatsapp/webhook
 
 # Forward messages sent by self (true/false)

--- a/.env.example
+++ b/.env.example
@@ -7,9 +7,12 @@ WHATSAPP_BRIDGE_PORT=8080
 # Webhook URL for incoming messages (optional)
 # Set this to forward incoming WhatsApp messages to another service. The bridge
 # authenticates every outbound webhook POST with the same bridge token it uses
-# for inbound REST auth, sent as "Authorization: Bearer <WHATSAPP_BRIDGE_TOKEN>"
-# (only when a token is configured). The receiving service must expect that same
-# token — see WHATSAPP_BRIDGE_TOKEN below.
+# for inbound REST auth, sent as an "X-Bridge-Token: <WHATSAPP_BRIDGE_TOKEN>"
+# header (only when a token is configured). A dedicated header is used instead
+# of Authorization so it never collides with a receiver's own Authorization-based
+# auth (e.g. HTTP Basic auth embedded in this URL as http://user:pass@host/...).
+# The receiving service must expect that same token — see WHATSAPP_BRIDGE_TOKEN
+# below.
 WEBHOOK_URL=http://localhost:8769/whatsapp/webhook
 
 # Forward messages sent by self (true/false)

--- a/README.md
+++ b/README.md
@@ -379,11 +379,16 @@ managers that do not share the store directory, set the same
 `WHATSAPP_BRIDGE_TOKEN` value for both the bridge and MCP server.
 
 The bridge also signs its **outbound** webhook POSTs (to `WEBHOOK_URL`) with this
-same token, sent as `Authorization: Bearer <token>`. The header is attached
+same token, sent as an `X-Bridge-Token: <token>` header — a dedicated header
+rather than `Authorization`, so it never collides with a receiver's own
+Authorization-based auth (e.g. HTTP Basic auth embedded in `WEBHOOK_URL` as
+`http://user:pass@host/...`, which `net/http` applies automatically as long as
+the bridge doesn't set its own `Authorization` header). The header is attached
 whenever a token is configured and omitted otherwise, so upgrades that predate a
 token rollout keep working. If your webhook receiver enforces the token, set its
 copy to this exact value: e.g. the AutoHub hub's `WHATSAPP_BRIDGE_TOKEN` must
-equal this bridge's token (from `.bridge-token` or its own env). The bridge always
+equal this bridge's token (from `.bridge-token` or its own env) — the hub
+accepts it via `X-Bridge-Token` or `Authorization: Bearer`. The bridge always
 sends the token it has; the hub rejects unauthenticated forwards only once its
 `WHATSAPP_BRIDGE_TOKEN` is set to the matching value.
 

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ Copy `.env.example` to `.env` and configure as needed:
 | `WHATSAPP_DB_PATH`     | `../whatsapp-bridge/store/messages.db`   | Path to SQLite database                      |
 | `WHATSMEOW_DB_PATH`    | `../whatsapp-bridge/store/whatsapp.db`   | whatsmeow DB used for LID ↔ phone resolution |
 | `WHATSAPP_API_URL`     | `http://localhost:8080/api`              | Go bridge REST API URL                       |
-| `WHATSAPP_BRIDGE_TOKEN` | generated next to `WHATSMEOW_DB_PATH` as `.bridge-token` | Bearer token required for bridge REST calls |
+| `WHATSAPP_BRIDGE_TOKEN` | generated next to `WHATSMEOW_DB_PATH` as `.bridge-token` | Bearer token for bridge REST calls; also signed onto outbound webhook POSTs |
 | `WHATSAPP_MEDIA_ROOTS` | `~/.local/share/whatsapp-mcp/outbox`     | Path-list of directories allowed for outbound media files |
 | `WHATSAPP_MCP_TRANSPORT` | `stdio`                                | MCP transport to serve clients: `stdio`, `http`, or `sse` |
 | `WHATSAPP_MCP_HOST`    | `127.0.0.1`                              | Bind address for the `http`/`sse` transports |
@@ -377,6 +377,15 @@ permissions, and prints a setup banner. The MCP server reads
 directory as `WHATSMEOW_DB_PATH`. For split deployments, containers, or process
 managers that do not share the store directory, set the same
 `WHATSAPP_BRIDGE_TOKEN` value for both the bridge and MCP server.
+
+The bridge also signs its **outbound** webhook POSTs (to `WEBHOOK_URL`) with this
+same token, sent as `Authorization: Bearer <token>`. The header is attached
+whenever a token is configured and omitted otherwise, so upgrades that predate a
+token rollout keep working. If your webhook receiver enforces the token, set its
+copy to this exact value: e.g. the AutoHub hub's `WHATSAPP_BRIDGE_TOKEN` must
+equal this bridge's token (from `.bridge-token` or its own env). The bridge always
+sends the token it has; the hub rejects unauthenticated forwards only once its
+`WHATSAPP_BRIDGE_TOKEN` is set to the matching value.
 
 Outbound `media_path` values are confined to `WHATSAPP_MEDIA_ROOTS`. The default
 outbox is `~/.local/share/whatsapp-mcp/outbox`, created on bridge startup. Move

--- a/README.md
+++ b/README.md
@@ -383,14 +383,20 @@ same token, sent as an `X-Bridge-Token: <token>` header — a dedicated header
 rather than `Authorization`, so it never collides with a receiver's own
 Authorization-based auth (e.g. HTTP Basic auth embedded in `WEBHOOK_URL` as
 `http://user:pass@host/...`, which `net/http` applies automatically as long as
-the bridge doesn't set its own `Authorization` header). The header is attached
-whenever a token is configured and omitted otherwise, so upgrades that predate a
-token rollout keep working. If your webhook receiver enforces the token, set its
-copy to this exact value: e.g. the AutoHub hub's `WHATSAPP_BRIDGE_TOKEN` must
-equal this bridge's token (from `.bridge-token` or its own env) — the hub
-accepts it via `X-Bridge-Token` or `Authorization: Bearer`. The bridge always
-sends the token it has; the hub rejects unauthenticated forwards only once its
-`WHATSAPP_BRIDGE_TOKEN` is set to the matching value.
+the bridge doesn't set its own `Authorization` header). The header is attached only when a token is configured **and** `WEBHOOK_URL` was
+explicitly set — never to the built-in local default. The bridge token also
+authorizes `/api/*` calls like sending messages, and nothing has vetted the
+implicit default address, so it must never be handed to whatever process
+happens to be listening there. Upgrades that predate the token rollout, or
+that never set `WEBHOOK_URL`, keep working unchanged. The webhook client also
+never follows redirects, so a misconfigured or malicious endpoint can't
+redirect the bridge into leaking the token to a different host. If your
+webhook receiver enforces the token, set its copy to this exact value: e.g.
+the AutoHub hub's `WHATSAPP_BRIDGE_TOKEN` must equal this bridge's token (from
+`.bridge-token` or its own env) — the hub accepts it via `X-Bridge-Token` or
+`Authorization: Bearer`. The bridge always sends the token it has; the hub
+rejects unauthenticated forwards only once its `WHATSAPP_BRIDGE_TOKEN` is set
+to the matching value.
 
 Outbound `media_path` values are confined to `WHATSAPP_MEDIA_ROOTS`. The default
 outbox is `~/.local/share/whatsapp-mcp/outbox`, created on bridge startup. Move

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -2577,6 +2577,10 @@ connectionSuccess:
 		printTokenBanner(bridgeToken, port)
 	}
 
+	// Attach the same bridge token to outbound webhook POSTs so the hub's
+	// fail-closed inbound-auth middleware accepts them. See webhook.go.
+	webhookAuthToken = bridgeToken
+
 	allowedMediaRoots, mrErr := resolveMediaRoots()
 	if mrErr != nil {
 		logger.Errorf("Failed to resolve media roots: %v", mrErr)

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -2343,6 +2343,21 @@ func main() {
 		return
 	}
 
+	// Load (or generate on first run) the bearer token used to authenticate
+	// REST callers, and attach it to outbound webhook POSTs so the hub's
+	// fail-closed inbound-auth middleware accepts them (see auth.go and
+	// webhook.go). This MUST happen before the event handler below is
+	// registered: WhatsApp can deliver messages — including a burst of
+	// history-sync backlog — as soon as the connection succeeds, and any
+	// message handled before this assignment would go out with no bridge
+	// token attached.
+	bridgeToken, fresh, tokErr := loadOrCreateBridgeToken()
+	if tokErr != nil {
+		logger.Errorf("Failed to initialize bridge token: %v", tokErr)
+		return
+	}
+	webhookAuthToken = bridgeToken
+
 	// Channel to signal reconnection needs
 	reconnectChan := make(chan bool, 1)
 
@@ -2564,23 +2579,14 @@ connectionSuccess:
 		port = v
 	}
 
-	// Load (or generate on first run) the bearer token used to authenticate
-	// REST callers, and resolve the allow-listed roots that media_path values
-	// in /api/send must live under. See auth.go and media_path.go for the
-	// rationale.
-	bridgeToken, fresh, tokErr := loadOrCreateBridgeToken()
-	if tokErr != nil {
-		logger.Errorf("Failed to initialize bridge token: %v", tokErr)
-		return
-	}
+	// bridgeToken was already loaded above (before the event handler was
+	// registered); print the one-time setup banner now that port is known.
 	if fresh {
 		printTokenBanner(bridgeToken, port)
 	}
 
-	// Attach the same bridge token to outbound webhook POSTs so the hub's
-	// fail-closed inbound-auth middleware accepts them. See webhook.go.
-	webhookAuthToken = bridgeToken
-
+	// Resolve the allow-listed roots that media_path values in /api/send must
+	// live under. See media_path.go for the rationale.
 	allowedMediaRoots, mrErr := resolveMediaRoots()
 	if mrErr != nil {
 		logger.Errorf("Failed to resolve media roots: %v", mrErr)

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -2343,6 +2343,20 @@ func main() {
 		return
 	}
 
+	// Resolve the REST API port. Pure env parsing with no dependency on the
+	// WhatsApp connection, so it's safe to do this early alongside the token
+	// load below — and failing fast here means we don't run a QR-pairing
+	// flow only to error out on an invalid port afterwards.
+	port := 8080
+	if p := os.Getenv("WHATSAPP_BRIDGE_PORT"); p != "" {
+		v, err := strconv.Atoi(p)
+		if err != nil || v < 1 || v > 65535 {
+			logger.Errorf("Invalid WHATSAPP_BRIDGE_PORT=%q, must be 1-65535", p)
+			return
+		}
+		port = v
+	}
+
 	// Load (or generate on first run) the bearer token used to authenticate
 	// REST callers, and attach it to outbound webhook POSTs so the hub's
 	// fail-closed inbound-auth middleware accepts them (see auth.go and
@@ -2357,6 +2371,17 @@ func main() {
 		return
 	}
 	webhookAuthToken = bridgeToken
+
+	// Print the one-time setup banner immediately, before attempting to
+	// connect/pair. loadOrCreateBridgeToken() already persisted the token to
+	// disk as soon as it generated one; if the banner instead waited until
+	// after a successful connection (as it used to), a QR-pairing timeout or
+	// early exit would leave a token on disk that was never shown to the
+	// user — and loadOrCreateBridgeToken() would report fresh=false on every
+	// later run, so the banner would never get a second chance to print it.
+	if fresh {
+		printTokenBanner(bridgeToken, port)
+	}
 
 	// Channel to signal reconnection needs
 	reconnectChan := make(chan bool, 1)
@@ -2568,22 +2593,8 @@ connectionSuccess:
 
 	fmt.Println("\n✓ Connected to WhatsApp! Type 'help' for commands.")
 
-	// Start REST API server
-	port := 8080
-	if p := os.Getenv("WHATSAPP_BRIDGE_PORT"); p != "" {
-		v, err := strconv.Atoi(p)
-		if err != nil || v < 1 || v > 65535 {
-			logger.Errorf("Invalid WHATSAPP_BRIDGE_PORT=%q, must be 1-65535", p)
-			return
-		}
-		port = v
-	}
-
-	// bridgeToken was already loaded above (before the event handler was
-	// registered); print the one-time setup banner now that port is known.
-	if fresh {
-		printTokenBanner(bridgeToken, port)
-	}
+	// port and bridgeToken were already resolved above, before the connect/
+	// pairing loop, so the setup banner could print immediately.
 
 	// Resolve the allow-listed roots that media_path values in /api/send must
 	// live under. See media_path.go for the rationale.

--- a/whatsapp-bridge/webhook.go
+++ b/whatsapp-bridge/webhook.go
@@ -17,8 +17,16 @@ const maxMediaBase64Bytes = 10 * 1024 * 1024 // 10 MB
 
 // webhookClient is used for all outbound webhook POSTs. The 30-second timeout
 // prevents a slow or unreachable endpoint from blocking message handling
-// indefinitely.
-var webhookClient = &http.Client{Timeout: 30 * time.Second}
+// indefinitely. Redirects are never followed: WEBHOOK_URL is a single
+// operator-configured endpoint, not a browsable URL, and following a 3xx
+// would forward X-Bridge-Token to whatever host the redirect names — Go only
+// strips Authorization/Cookie on cross-origin redirects, not custom headers.
+var webhookClient = &http.Client{
+	Timeout: 30 * time.Second,
+	CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	},
+}
 
 // webhookAuthToken is the shared bridge token attached as an
 // "X-Bridge-Token" header to every outbound webhook POST. It is populated
@@ -33,6 +41,13 @@ var webhookClient = &http.Client{Timeout: 30 * time.Second}
 // Authorization-based auth — e.g. HTTP Basic auth that net/http derives
 // automatically from credentials embedded in WEBHOOK_URL.
 var webhookAuthToken string
+
+// defaultWebhookURL is used when WEBHOOK_URL is not set. It is a var (not a
+// const) so tests can point it at a local test server. It must never receive
+// the bridge token: unlike an operator-configured WEBHOOK_URL, nothing has
+// vetted this address, so any other local process that happens to bind this
+// port could otherwise capture the token just by being reachable.
+var defaultWebhookURL = "http://localhost:8769/whatsapp/webhook"
 
 // WebhookPayload represents the data sent to the webhook
 type WebhookPayload struct {
@@ -59,8 +74,9 @@ type WebhookPayload struct {
 // sendWebhookPayload marshals and POSTs a WebhookPayload to the configured webhook URL.
 func sendWebhookPayload(payload WebhookPayload) {
 	webhookURL := os.Getenv("WEBHOOK_URL")
-	if webhookURL == "" {
-		webhookURL = "http://localhost:8769/whatsapp/webhook"
+	explicitlyConfigured := webhookURL != ""
+	if !explicitlyConfigured {
+		webhookURL = defaultWebhookURL
 	}
 
 	jsonData, err := json.Marshal(payload)
@@ -78,9 +94,11 @@ func sendWebhookPayload(payload WebhookPayload) {
 	// Authenticate to the hub's fail-closed inbound webhook route with the
 	// shared bridge token, via a dedicated header so it can never clobber a
 	// receiver's own Authorization-based auth (see webhookAuthToken doc
-	// comment above). Only attach the header when a token is configured so
-	// nothing breaks before the hub's WHATSAPP_BRIDGE_TOKEN is rolled out.
-	if webhookAuthToken != "" {
+	// comment above). Only attach it when BOTH a token is configured AND
+	// WEBHOOK_URL was explicitly set by the operator — the bridge token also
+	// authorizes /api/* calls like sending messages, and the implicit local
+	// default is not a destination anyone vetted, so it must never receive it.
+	if webhookAuthToken != "" && explicitlyConfigured {
 		req.Header.Set("X-Bridge-Token", webhookAuthToken)
 	}
 

--- a/whatsapp-bridge/webhook.go
+++ b/whatsapp-bridge/webhook.go
@@ -20,6 +20,16 @@ const maxMediaBase64Bytes = 10 * 1024 * 1024 // 10 MB
 // indefinitely.
 var webhookClient = &http.Client{Timeout: 30 * time.Second}
 
+// webhookAuthToken is the shared bridge token attached as an
+// "Authorization: Bearer <token>" header to every outbound webhook POST. It is
+// populated once at startup from loadOrCreateBridgeToken() (see auth.go and
+// main.go) — the same token the bridge already requires on inbound /api/*
+// requests. When empty (no token configured yet) the header is omitted so
+// deployments that predate the token rollout keep working. The receiving hub
+// enforces this token on its inbound webhook route once its own
+// WHATSAPP_BRIDGE_TOKEN is set to the matching value (autohub PR #898).
+var webhookAuthToken string
+
 // WebhookPayload represents the data sent to the webhook
 type WebhookPayload struct {
 	EventType       string `json:"eventType,omitempty"`
@@ -55,7 +65,20 @@ func sendWebhookPayload(payload WebhookPayload) {
 		return
 	}
 
-	resp, err := webhookClient.Post(webhookURL, "application/json", bytes.NewBuffer(jsonData))
+	req, err := http.NewRequest(http.MethodPost, webhookURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		fmt.Printf("Error building webhook request: %v\n", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	// Authenticate to the hub's fail-closed inbound webhook route with the
+	// shared bridge token. Only attach the header when a token is configured so
+	// nothing breaks before the hub's WHATSAPP_BRIDGE_TOKEN is rolled out.
+	if webhookAuthToken != "" {
+		req.Header.Set("Authorization", "Bearer "+webhookAuthToken)
+	}
+
+	resp, err := webhookClient.Do(req)
 	if err != nil {
 		fmt.Printf("Error sending webhook: %v\n", err)
 		return

--- a/whatsapp-bridge/webhook.go
+++ b/whatsapp-bridge/webhook.go
@@ -21,13 +21,17 @@ const maxMediaBase64Bytes = 10 * 1024 * 1024 // 10 MB
 var webhookClient = &http.Client{Timeout: 30 * time.Second}
 
 // webhookAuthToken is the shared bridge token attached as an
-// "Authorization: Bearer <token>" header to every outbound webhook POST. It is
-// populated once at startup from loadOrCreateBridgeToken() (see auth.go and
-// main.go) — the same token the bridge already requires on inbound /api/*
-// requests. When empty (no token configured yet) the header is omitted so
-// deployments that predate the token rollout keep working. The receiving hub
-// enforces this token on its inbound webhook route once its own
-// WHATSAPP_BRIDGE_TOKEN is set to the matching value (autohub PR #898).
+// "X-Bridge-Token" header to every outbound webhook POST. It is populated
+// once at startup from loadOrCreateBridgeToken() (see auth.go and main.go) —
+// the same token the bridge already requires on inbound /api/* requests.
+// When empty (no token configured yet) the header is omitted so deployments
+// that predate the token rollout keep working. The receiving hub enforces
+// this token on its inbound webhook route once its own WHATSAPP_BRIDGE_TOKEN
+// is set to the matching value (autohub PR #898), which accepts the token via
+// this header or "Authorization: Bearer". A dedicated header is used here
+// (rather than Authorization) so it never collides with a receiver's own
+// Authorization-based auth — e.g. HTTP Basic auth that net/http derives
+// automatically from credentials embedded in WEBHOOK_URL.
 var webhookAuthToken string
 
 // WebhookPayload represents the data sent to the webhook
@@ -72,10 +76,12 @@ func sendWebhookPayload(payload WebhookPayload) {
 	}
 	req.Header.Set("Content-Type", "application/json")
 	// Authenticate to the hub's fail-closed inbound webhook route with the
-	// shared bridge token. Only attach the header when a token is configured so
+	// shared bridge token, via a dedicated header so it can never clobber a
+	// receiver's own Authorization-based auth (see webhookAuthToken doc
+	// comment above). Only attach the header when a token is configured so
 	// nothing breaks before the hub's WHATSAPP_BRIDGE_TOKEN is rolled out.
 	if webhookAuthToken != "" {
-		req.Header.Set("Authorization", "Bearer "+webhookAuthToken)
+		req.Header.Set("X-Bridge-Token", webhookAuthToken)
 	}
 
 	resp, err := webhookClient.Do(req)

--- a/whatsapp-bridge/webhook_test.go
+++ b/whatsapp-bridge/webhook_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// setWebhookAuthToken sets the package-level outbound webhook token for the
+// duration of a test and restores the previous value on cleanup.
+func setWebhookAuthToken(t *testing.T, token string) {
+	t.Helper()
+	prev := webhookAuthToken
+	webhookAuthToken = token
+	t.Cleanup(func() { webhookAuthToken = prev })
+}
+
+// TestSendWebhookAttachesBearerToken verifies that outbound webhook POSTs carry
+// the shared bridge token as an "Authorization: Bearer <token>" header so the
+// hub's fail-closed inbound-auth middleware (autohub PR #898) accepts them.
+func TestSendWebhookAttachesBearerToken(t *testing.T) {
+	const token = "test-bridge-token-1234567890abcdef"
+
+	var gotAuth, gotContentType string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotContentType = r.Header.Get("Content-Type")
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	t.Setenv("WEBHOOK_URL", srv.URL)
+	setWebhookAuthToken(t, token)
+
+	SendWebhook("123@s.whatsapp.net", "hello", "123@s.whatsapp.net", false, "", "", "")
+
+	if want := "Bearer " + token; gotAuth != want {
+		t.Fatalf("Authorization header = %q, want %q", gotAuth, want)
+	}
+	if gotContentType != "application/json" {
+		t.Fatalf("Content-Type header = %q, want application/json", gotContentType)
+	}
+}
+
+// TestSendWebhookOmitsBearerWhenNoToken verifies that when no bridge token is
+// configured the webhook still fires WITHOUT an Authorization header, so
+// deployments that predate the token rollout keep working.
+func TestSendWebhookOmitsBearerWhenNoToken(t *testing.T) {
+	var gotAuth string
+	var received bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received = true
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	t.Setenv("WEBHOOK_URL", srv.URL)
+	setWebhookAuthToken(t, "")
+
+	SendWebhook("123@s.whatsapp.net", "hi", "123@s.whatsapp.net", false, "", "", "")
+
+	if !received {
+		t.Fatal("webhook was not delivered")
+	}
+	if gotAuth != "" {
+		t.Fatalf("expected no Authorization header, got %q", gotAuth)
+	}
+}

--- a/whatsapp-bridge/webhook_test.go
+++ b/whatsapp-bridge/webhook_test.go
@@ -18,6 +18,16 @@ func setWebhookAuthToken(t *testing.T, token string) {
 	t.Cleanup(func() { webhookAuthToken = prev })
 }
 
+// setDefaultWebhookURL points the built-in fallback webhook URL (used when
+// WEBHOOK_URL is unset) at a test server for the duration of a test, and
+// restores the previous value on cleanup.
+func setDefaultWebhookURL(t *testing.T, url string) {
+	t.Helper()
+	prev := defaultWebhookURL
+	defaultWebhookURL = url
+	t.Cleanup(func() { defaultWebhookURL = prev })
+}
+
 // TestSendWebhookAttachesBridgeTokenHeader verifies that outbound webhook POSTs
 // carry the shared bridge token as an "X-Bridge-Token" header so the hub's
 // fail-closed inbound-auth middleware (autohub PR #898) accepts them. The token
@@ -112,5 +122,77 @@ func TestSendWebhookPreservesURLBasicAuth(t *testing.T) {
 	}
 	if gotToken != token {
 		t.Fatalf("X-Bridge-Token header = %q, want %q", gotToken, token)
+	}
+}
+
+// TestSendWebhookOmitsBridgeTokenOnImplicitDefaultURL is a regression test for
+// a Codex review finding on PR #153: when WEBHOOK_URL is left unset,
+// sendWebhookPayload falls back to a hardcoded local default. That default is
+// not something the operator configured or vetted, so the REST bridge token
+// (which also authorizes /api/* calls like sending messages) must never be
+// attached to it — otherwise any other local process that happens to bind
+// that port could capture the token simply by being reachable. The token
+// must only ever go to a WEBHOOK_URL the operator explicitly set.
+func TestSendWebhookOmitsBridgeTokenOnImplicitDefaultURL(t *testing.T) {
+	const token = "test-bridge-token-1234567890abcdef"
+
+	var gotToken string
+	var received bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received = true
+		gotToken = r.Header.Get("X-Bridge-Token")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	t.Setenv("WEBHOOK_URL", "") // explicitly unset — exercise the fallback path
+	setDefaultWebhookURL(t, srv.URL)
+	setWebhookAuthToken(t, token)
+
+	SendWebhook("123@s.whatsapp.net", "hi", "123@s.whatsapp.net", false, "", "", "")
+
+	if !received {
+		t.Fatal("webhook was not delivered to the default URL")
+	}
+	if gotToken != "" {
+		t.Fatalf("expected no X-Bridge-Token header on the implicit default URL, got %q", gotToken)
+	}
+}
+
+// TestSendWebhookDoesNotFollowRedirects is a regression test for a Codex
+// review finding on PR #153: Go's default http.Client follows redirects and
+// forwards custom headers to the redirect target regardless of host, unlike
+// Authorization/Cookie which it strips cross-origin. A misconfigured or
+// malicious WEBHOOK_URL that responds with a 3xx could otherwise cause the
+// bridge to leak X-Bridge-Token to an arbitrary third-party host. The webhook
+// client must not follow redirects at all, so a second host is never
+// contacted.
+func TestSendWebhookDoesNotFollowRedirects(t *testing.T) {
+	const token = "test-bridge-token-1234567890abcdef"
+
+	var targetHit bool
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetHit = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	var redirectHit bool
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectHit = true
+		http.Redirect(w, r, target.URL+"/whatsapp/webhook", http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	t.Setenv("WEBHOOK_URL", redirector.URL)
+	setWebhookAuthToken(t, token)
+
+	SendWebhook("123@s.whatsapp.net", "hi", "123@s.whatsapp.net", false, "", "", "")
+
+	if !redirectHit {
+		t.Fatal("expected the configured webhook URL to be hit")
+	}
+	if targetHit {
+		t.Fatal("bridge must not follow redirects to a different host (would leak X-Bridge-Token)")
 	}
 }

--- a/whatsapp-bridge/webhook_test.go
+++ b/whatsapp-bridge/webhook_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"encoding/base64"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 )
 
@@ -16,15 +18,18 @@ func setWebhookAuthToken(t *testing.T, token string) {
 	t.Cleanup(func() { webhookAuthToken = prev })
 }
 
-// TestSendWebhookAttachesBearerToken verifies that outbound webhook POSTs carry
-// the shared bridge token as an "Authorization: Bearer <token>" header so the
-// hub's fail-closed inbound-auth middleware (autohub PR #898) accepts them.
-func TestSendWebhookAttachesBearerToken(t *testing.T) {
+// TestSendWebhookAttachesBridgeTokenHeader verifies that outbound webhook POSTs
+// carry the shared bridge token as an "X-Bridge-Token" header so the hub's
+// fail-closed inbound-auth middleware (autohub PR #898) accepts them. The token
+// travels on a dedicated header, not Authorization, so it never collides with a
+// receiver's own Authorization-based auth (see
+// TestSendWebhookPreservesURLBasicAuth).
+func TestSendWebhookAttachesBridgeTokenHeader(t *testing.T) {
 	const token = "test-bridge-token-1234567890abcdef"
 
-	var gotAuth, gotContentType string
+	var gotToken, gotContentType string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotAuth = r.Header.Get("Authorization")
+		gotToken = r.Header.Get("X-Bridge-Token")
 		gotContentType = r.Header.Get("Content-Type")
 		_, _ = io.Copy(io.Discard, r.Body)
 		w.WriteHeader(http.StatusOK)
@@ -36,23 +41,23 @@ func TestSendWebhookAttachesBearerToken(t *testing.T) {
 
 	SendWebhook("123@s.whatsapp.net", "hello", "123@s.whatsapp.net", false, "", "", "")
 
-	if want := "Bearer " + token; gotAuth != want {
-		t.Fatalf("Authorization header = %q, want %q", gotAuth, want)
+	if gotToken != token {
+		t.Fatalf("X-Bridge-Token header = %q, want %q", gotToken, token)
 	}
 	if gotContentType != "application/json" {
 		t.Fatalf("Content-Type header = %q, want application/json", gotContentType)
 	}
 }
 
-// TestSendWebhookOmitsBearerWhenNoToken verifies that when no bridge token is
-// configured the webhook still fires WITHOUT an Authorization header, so
-// deployments that predate the token rollout keep working.
-func TestSendWebhookOmitsBearerWhenNoToken(t *testing.T) {
-	var gotAuth string
+// TestSendWebhookOmitsBridgeTokenHeaderWhenNoToken verifies that when no bridge
+// token is configured the webhook still fires WITHOUT an X-Bridge-Token header,
+// so deployments that predate the token rollout keep working.
+func TestSendWebhookOmitsBridgeTokenHeaderWhenNoToken(t *testing.T) {
+	var gotToken string
 	var received bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		received = true
-		gotAuth = r.Header.Get("Authorization")
+		gotToken = r.Header.Get("X-Bridge-Token")
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
@@ -65,7 +70,47 @@ func TestSendWebhookOmitsBearerWhenNoToken(t *testing.T) {
 	if !received {
 		t.Fatal("webhook was not delivered")
 	}
-	if gotAuth != "" {
-		t.Fatalf("expected no Authorization header, got %q", gotAuth)
+	if gotToken != "" {
+		t.Fatalf("expected no X-Bridge-Token header, got %q", gotToken)
+	}
+}
+
+// TestSendWebhookPreservesURLBasicAuth is a regression test for a Codex review
+// finding on PR #153: net/http automatically derives an "Authorization: Basic"
+// header from credentials embedded in the webhook URL (http://user:pass@host/...)
+// whenever the outgoing request's Authorization header is otherwise unset. An
+// earlier version of this fix sent the bridge token via Authorization, which
+// silently clobbered that behavior for any receiver relying on URL userinfo.
+// Sending the token as X-Bridge-Token instead must leave Authorization
+// untouched so Go's built-in URL-credential handling keeps working.
+func TestSendWebhookPreservesURLBasicAuth(t *testing.T) {
+	const user, pass = "hookuser", "hookpass"
+	const token = "test-bridge-token-1234567890abcdef"
+
+	var gotAuth, gotToken string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotToken = r.Header.Get("X-Bridge-Token")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("failed to parse test server URL: %v", err)
+	}
+	u.User = url.UserPassword(user, pass)
+
+	t.Setenv("WEBHOOK_URL", u.String())
+	setWebhookAuthToken(t, token)
+
+	SendWebhook("123@s.whatsapp.net", "hello", "123@s.whatsapp.net", false, "", "", "")
+
+	wantAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte(user+":"+pass))
+	if gotAuth != wantAuth {
+		t.Fatalf("Authorization header = %q, want %q (URL basic auth must survive)", gotAuth, wantAuth)
+	}
+	if gotToken != token {
+		t.Fatalf("X-Bridge-Token header = %q, want %q", gotToken, token)
 	}
 }


### PR DESCRIPTION
## Summary

The Go bridge POSTs inbound WhatsApp messages to `WEBHOOK_URL` but sent **no authentication header**. AutoHub [PR #898](https://github.com/verygoodplugins/autohub/pull/898) closed a P0 by making the hub's `POST /whatsapp/webhook` route **fail-closed**: a new bridge-auth middleware requires the shared bridge token on the inbound request as `Authorization: Bearer <token>` (or `x-bridge-token`), constant-time compared. Once the hub's `WHATSAPP_BRIDGE_TOKEN` is set, this bridge's unauthenticated POSTs would be rejected (401) and inbound WhatsApp forwarding would silently break.

This change makes the bridge sign every outbound webhook POST with the same token it already requires on its **inbound** `/api/*` requests.

## What changed

- **`whatsapp-bridge/webhook.go`** — `sendWebhookPayload` no longer uses `http.Client.Post` (which can't set custom headers). It now builds the request with `http.NewRequest(http.MethodPost, ...)`, sets `Content-Type: application/json`, conditionally sets `Authorization: Bearer <token>`, and sends via `webhookClient.Do(req)`. All three inbound paths (`SendWebhook`, `SendWebhookWithMedia`, `SendReactionWebhook`) funnel through `sendWebhookPayload`, so this single change covers all of them.
- **`whatsapp-bridge/main.go`** — at startup the existing `loadOrCreateBridgeToken()` result is assigned to a new package-level `webhookAuthToken`, mirroring how the same token already authenticates inbound `/api/*` requests.
- **The header is only attached when a token is configured** (`webhookAuthToken != ""`), so deployments that predate a token rollout keep working unchanged.
- **Docs** — `README.md` and `.env.example` now document that the receiving hub's `WHATSAPP_BRIDGE_TOKEN` must equal this bridge's token (from `store/.bridge-token` or its own env). The bridge always sends the token it has; the hub enforces only once its `WHATSAPP_BRIDGE_TOKEN` is set to the matching value.

## Tests (red → green)

Added `whatsapp-bridge/webhook_test.go`, which stands up an `httptest.Server` as a fake hub, calls `SendWebhook(...)`, and asserts the received request carried `Authorization: Bearer <token>` (plus `Content-Type: application/json`). A second test asserts the pre-rollout path: with no token configured the webhook still fires **without** an `Authorization` header.

- **RED** (before the `webhook.go` fix, header not yet attached):
  ```
  --- FAIL: TestSendWebhookAttachesBearerToken (0.00s)
      webhook_test.go:40: Authorization header = "", want "Bearer test-bridge-token-1234567890abcdef"
  ```
- **GREEN** (after the fix):
  ```
  --- PASS: TestSendWebhookAttachesBearerToken (0.00s)
  --- PASS: TestSendWebhookOmitsBearerWhenNoToken (0.00s)
  ok  	whatsapp-client
  ```

Full local run (from `whatsapp-bridge/`, per `AGENTS.md`):

```
go build ./...      # OK
go vet ./...        # OK
golangci-lint run   # 0 issues
go test ./...       # ok  whatsapp-client
```

## Security-sensitive

This touches auth on an outbound network call. The token reuses the existing 256-bit bridge secret and is only sent to the operator-configured `WEBHOOK_URL`; the header is omitted entirely when no token exists (no behavior change pre-rollout). No new dependencies, no new env vars.

## Rollout / coordination

1. Deploy this bridge (it starts sending the header immediately; harmless while the hub still accepts unauthenticated posts).
2. Set the hub's `WHATSAPP_BRIDGE_TOKEN` to **equal** this bridge's token — at that point the hub begins enforcing and only authenticated forwards from this bridge succeed.

Coordinated follow-up to autohub [PR #898](https://github.com/verygoodplugins/autohub/pull/898).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
