### PR TITLE
feat(bridge): persist chat read state from read receipts + history-sync backfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,42 @@ Download media from a received message.
 
 ### Chat Operations
 
+All chat tools (`list_chats`, `get_chat`, `get_direct_chat_by_contact`,
+`get_contact_chats`) return the same chat shape:
+
+```jsonc
+{
+  "jid": "1234567890@s.whatsapp.net",
+  "name": "Alice",
+  "is_group": false,
+  "last_message_time": "2024-01-15T10:30:00+00:00",
+  "last_message": "hello world",       // null when include_last_message=false
+  "last_sender": "1234567890",         // null when include_last_message=false
+  "last_is_from_me": false,
+  "last_read_time": "2024-01-15T09:00:00+00:00", // how far the chat is read
+  "unread": true                       // last message is inbound and unread
+}
+```
+
+#### Read state (`last_read_time` / `unread`)
+
+`last_read_time` is the bridge's read marker for the chat, fed by read
+receipts from your own devices and backfilled from history sync. `unread` is
+derived from it: true when the chat's last message is inbound and newer than
+the marker. This distinguishes a genuinely unread chat from one whose last
+message merely happens to be inbound but was already read on the phone.
+
+Caveats:
+
+- **The marker only moves forward.** Marking an already-read chat as *unread*
+  again on the phone is not reflected.
+- **No marker means no read was ever reported** — for a chat with an inbound
+  last message, `unread` then falls back to the old heuristic and reports
+  true. Stores written by a bridge older than the `chats.last_read_time`
+  column report `last_read_time: null` and behave the same way.
+- **`unread` is a chat-level flag, not an unread count.** WhatsApp's unread
+  counter is not persisted.
+
 #### `list_chats`
 
 List all chats with metadata.

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -196,6 +196,9 @@ func ensureMessageStoreSchema(db *sql.DB) error {
 	if err := ensureColumn(db, "chats", "ephemeral_setting_timestamp", "INTEGER NOT NULL DEFAULT 0"); err != nil {
 		return fmt.Errorf("failed to ensure chats.ephemeral_setting_timestamp column: %w", err)
 	}
+	if err := ensureColumn(db, "chats", "last_read_time", "TIMESTAMP"); err != nil {
+		return fmt.Errorf("failed to ensure chats.last_read_time column: %w", err)
+	}
 	if err := ensureColumn(db, "messages", "deleted_at", "TIMESTAMP"); err != nil {
 		return fmt.Errorf("failed to ensure messages.deleted_at column: %w", err)
 	}
@@ -639,6 +642,27 @@ func (store *MessageStore) UpdateChatEphemeralSettings(jid string, expiration ui
 			ephemeral_setting_timestamp = excluded.ephemeral_setting_timestamp
 		WHERE excluded.ephemeral_setting_timestamp >= chats.ephemeral_setting_timestamp`,
 		jid, expiration, settingTimestamp,
+	)
+	return err
+}
+
+// MarkChatRead records that we read the chat up to readAt. The marker merges
+// monotonically — out-of-order receipts and history-sync backfill can never
+// move it backwards and un-read a chat. Like UpdateChatEphemeralSettings it
+// inserts only its own column, leaving name/last_message_time NULL so a receipt
+// arriving before any StoreChat call doesn't fabricate placeholder metadata.
+func (store *MessageStore) MarkChatRead(jid string, readAt time.Time) error {
+	_, err := store.db.Exec(
+		`INSERT INTO chats (jid, last_read_time)
+		VALUES (?, ?)
+		ON CONFLICT(jid) DO UPDATE SET
+			last_read_time = CASE
+				WHEN chats.last_read_time IS NULL THEN excluded.last_read_time
+				WHEN excluded.last_read_time IS NULL THEN chats.last_read_time
+				WHEN excluded.last_read_time > chats.last_read_time THEN excluded.last_read_time
+				ELSE chats.last_read_time
+			END`,
+		jid, readAt,
 	)
 	return err
 }
@@ -1483,6 +1507,15 @@ func resolveLIDChat(client *whatsmeow.Client, chat, senderAlt, recipientAlt type
 
 	fmt.Printf("Warning: could not resolve LID chat %s to phone JID\n", chat)
 	return chat
+}
+
+// isSelfReadReceipt reports whether a receipt means WE read the chat (on this
+// or another device), as opposed to another user reading our outgoing message.
+// A DM self-read arrives as read-self; a group self-read arrives as a plain
+// read whose participant is us (IsFromMe). See types.ReceiptType docs.
+func isSelfReadReceipt(receipt *events.Receipt) bool {
+	return receipt.Type == types.ReceiptTypeReadSelf ||
+		(receipt.Type == types.ReceiptTypeRead && receipt.IsFromMe)
 }
 
 // resolveUserJID resolves a single user JID (sender or participant) to its
@@ -2397,6 +2430,16 @@ func main() {
 			// Process history sync events
 			handleHistorySync(client, messageStore, v, logger)
 
+		case *events.Receipt:
+			// Persist read state so consumers can distinguish genuine unread
+			// from "latest message is inbound". Only our own reads count.
+			if isSelfReadReceipt(v) {
+				chatJID := resolveLIDChat(client, v.Chat, v.SenderAlt, v.RecipientAlt, v.IsFromMe).String()
+				if err := messageStore.MarkChatRead(chatJID, v.Timestamp); err != nil {
+					logger.Warnf("Failed to mark chat %s read: %v", chatJID, err)
+				}
+			}
+
 		case *events.GroupInfo:
 			if v.Ephemeral != nil {
 				expiration := uint32(0)
@@ -2890,6 +2933,15 @@ func handleHistorySync(client *whatsmeow.Client, messageStore *MessageStore, his
 			timestamp := time.Unix(int64(ts), 0)
 
 			_ = messageStore.StoreChat(chatJID, name, timestamp)
+			// Backfill read state: a conversation WhatsApp reports as fully
+			// read (no unread count, not manually flagged) is read up to its
+			// last message. Conversations with genuine unread are left
+			// unmarked so they correctly stay "awaiting".
+			if conversation.GetUnreadCount() == 0 && !conversation.GetMarkedAsUnread() {
+				if err := messageStore.MarkChatRead(chatJID, timestamp); err != nil {
+					logger.Warnf("Failed to backfill read state for %s: %v", chatJID, err)
+				}
+			}
 			if err := messageStore.UpdateChatEphemeralSettings(
 				chatJID,
 				conversation.GetEphemeralExpiration(),

--- a/whatsapp-bridge/main_test.go
+++ b/whatsapp-bridge/main_test.go
@@ -87,6 +87,7 @@ func newTestMessageStore(t *testing.T) *MessageStore {
 			jid TEXT PRIMARY KEY,
 			name TEXT,
 			last_message_time TIMESTAMP,
+			last_read_time TIMESTAMP,
 			ephemeral_expiration INTEGER NOT NULL DEFAULT 0,
 			ephemeral_setting_timestamp INTEGER NOT NULL DEFAULT 0
 		);
@@ -344,6 +345,69 @@ func TestUpdateChatEphemeralSettings_IgnoresOlderTimestamp(t *testing.T) {
 	}
 }
 
+// TestMarkChatRead_AdvancesButNeverRegresses locks the monotonic merge: a
+// read marker is set when absent, advances on a newer read, and is never
+// moved backwards by an older read (out-of-order receipts / history-sync
+// backfill must not un-read a chat).
+func TestMarkChatRead_AdvancesButNeverRegresses(t *testing.T) {
+	ms := newTestMessageStore(t)
+	chatJID := "15551234567@s.whatsapp.net"
+	early := time.Unix(1710000000, 0)
+	late := time.Unix(1710009999, 0)
+
+	// sets when absent (INSERT path, no prior chat row)
+	if err := ms.MarkChatRead(chatJID, early); err != nil {
+		t.Fatalf("initial mark: %v", err)
+	}
+	got1, ok := queryChatLastReadTime(ms, chatJID)
+	if !ok || got1 == "" {
+		t.Fatalf("expected last_read_time to be set, got %q ok=%v", got1, ok)
+	}
+
+	// advances on a newer read
+	if err := ms.MarkChatRead(chatJID, late); err != nil {
+		t.Fatalf("advance mark: %v", err)
+	}
+	got2, _ := queryChatLastReadTime(ms, chatJID)
+	if got2 == got1 {
+		t.Fatalf("expected last_read_time to advance from %q, still %q", got1, got2)
+	}
+
+	// does NOT regress on an older read
+	if err := ms.MarkChatRead(chatJID, early); err != nil {
+		t.Fatalf("regress mark: %v", err)
+	}
+	got3, _ := queryChatLastReadTime(ms, chatJID)
+	if got3 != got2 {
+		t.Fatalf("expected no regress from %q, got %q", got2, got3)
+	}
+}
+
+// TestIsSelfReadReceipt covers the classification used by the Receipt handler:
+// a read is "ours" when it's a DM read-self, or a group read whose participant
+// is us (IsFromMe) — but never another user reading our outgoing message.
+func TestIsSelfReadReceipt(t *testing.T) {
+	cases := []struct {
+		name   string
+		typ    types.ReceiptType
+		fromMe bool
+		want   bool
+	}{
+		{"dm read-self", types.ReceiptTypeReadSelf, false, true},
+		{"group read by us", types.ReceiptTypeRead, true, true},
+		{"other user read our message", types.ReceiptTypeRead, false, false},
+		{"delivered", types.ReceiptTypeDelivered, false, false},
+		{"sender", types.ReceiptTypeSender, false, false},
+	}
+	for _, c := range cases {
+		r := &events.Receipt{Type: c.typ}
+		r.IsFromMe = c.fromMe
+		if got := isSelfReadReceipt(r); got != c.want {
+			t.Errorf("%s: isSelfReadReceipt=%v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
 // TestExtractChatEphemeralFromMessage covers every concrete sub-message type
 // that carries ContextInfo. Each regular message in an ephemeral chat stamps
 // ContextInfo.Expiration / EphemeralSettingTimestamp; the bridge backfills
@@ -520,6 +584,14 @@ func queryChat(ms *MessageStore, jid string) (name string, found bool) {
 func queryChatLastMessageTime(ms *MessageStore, jid string) (lastMessageTime string, found bool) {
 	err := ms.db.QueryRow("SELECT last_message_time FROM chats WHERE jid = ?", jid).Scan(&lastMessageTime)
 	return lastMessageTime, err == nil
+}
+
+// queryChatLastReadTime returns the last_read_time for a chat JID as stored
+// text (NULL becomes the empty string), plus whether the row exists.
+func queryChatLastReadTime(ms *MessageStore, jid string) (lastReadTime string, found bool) {
+	var lr sql.NullString
+	err := ms.db.QueryRow("SELECT last_read_time FROM chats WHERE jid = ?", jid).Scan(&lr)
+	return lr.String, err == nil
 }
 
 // queryMessageCount returns the number of messages stored under a chat JID.

--- a/whatsapp-mcp-server/main.py
+++ b/whatsapp-mcp-server/main.py
@@ -224,6 +224,13 @@ def list_chats(
         page: Page number for pagination (default 0)
         include_last_message: Include the last message in each chat (default True)
         sort_by: "last_active" (default, most recent first) or "name" (alphabetical)
+
+    Returns:
+        Chat dictionaries with jid, name, is_group, last_message_time, last_message,
+        last_sender, last_is_from_me, last_read_time and unread. `last_read_time` is
+        how far the chat has been read on any device (null if never reported); `unread`
+        is true when the last message is inbound and newer than that marker, so chats
+        already read on the phone are not reported as unread.
     """
     # Cap limit at 200 to prevent excessive queries
     limit = min(limit, 200)
@@ -240,6 +247,9 @@ def get_chat(chat_jid: str, include_last_message: bool = True) -> dict[str, Any]
     Args:
         chat_jid: The JID of the chat to retrieve
         include_last_message: Whether to include the last message (default True)
+
+    Returns:
+        Chat dictionary — same shape as list_chats, including last_read_time and unread.
     """
     chat = whatsapp_get_chat(chat_jid, include_last_message)
     return chat

--- a/whatsapp-mcp-server/tests/test_list_chats.py
+++ b/whatsapp-mcp-server/tests/test_list_chats.py
@@ -84,14 +84,15 @@ def test_list_chats_with_last_message(messages_db):
 
 def test_list_chats_without_last_message(messages_db):
     """Regression: include_last_message=False must not error and must
-    still return the chat row with NULL last-message fields."""
+    still return the chat row without the last message's content."""
     chats = whatsapp.list_chats(limit=10, include_last_message=False)
     assert len(chats) == 1
     assert chats[0]["jid"] == "1234567890@s.whatsapp.net"
     assert chats[0]["name"] == "Alice"
     assert chats[0]["last_message"] is None
     assert chats[0]["last_sender"] is None
-    assert chats[0]["last_is_from_me"] is None
+    # is_from_me is always joined — the unread flag is derived from it.
+    assert chats[0]["last_is_from_me"] == 0
 
 
 def test_list_chats_query_filter_with_include_last_message_false(messages_db):
@@ -119,7 +120,7 @@ def test_get_chat_without_last_message(messages_db):
     assert chat["name"] == "Alice"
     assert chat["last_message"] is None
     assert chat["last_sender"] is None
-    assert chat["last_is_from_me"] is None
+    assert chat["last_is_from_me"] == 0
 
 
 def test_get_chat_missing_jid_returns_none(messages_db):

--- a/whatsapp-mcp-server/tests/test_read_state.py
+++ b/whatsapp-mcp-server/tests/test_read_state.py
@@ -1,0 +1,154 @@
+"""End-to-end tests for the chat read-state read path.
+
+The bridge records how far each chat has been read in chats.last_read_time
+(read receipts + history-sync backfill). These tests cover the MCP side:
+that the marker is surfaced on every chat tool and that the derived `unread`
+flag distinguishes a genuinely unread chat from one whose last message merely
+happens to be inbound.
+"""
+
+import sqlite3
+
+import pytest
+
+import whatsapp
+
+CHATS = [
+    # (jid, name, last_message_time, last_read_time, last message is_from_me)
+    ("unread@s.whatsapp.net", "Unread", "2024-01-15 10:30:00+00:00", "2024-01-15 09:00:00+00:00", 0),
+    ("read@s.whatsapp.net", "Read", "2024-01-15 10:30:00+00:00", "2024-01-15 11:00:00+00:00", 0),
+    ("mine@s.whatsapp.net", "Mine", "2024-01-15 10:30:00+00:00", None, 1),
+    ("nomarker@s.whatsapp.net", "NoMarker", "2024-01-15 10:30:00+00:00", None, 0),
+]
+
+SCHEMA_WITH_READ_STATE = """
+    CREATE TABLE chats (
+        jid TEXT PRIMARY KEY,
+        name TEXT,
+        last_message_time TIMESTAMP,
+        last_read_time TIMESTAMP
+    );
+"""
+
+# A store written by a bridge that predates the read-state migration.
+SCHEMA_WITHOUT_READ_STATE = """
+    CREATE TABLE chats (
+        jid TEXT PRIMARY KEY,
+        name TEXT,
+        last_message_time TIMESTAMP
+    );
+"""
+
+MESSAGES_SCHEMA = """
+    CREATE TABLE messages (
+        id TEXT,
+        chat_jid TEXT,
+        sender TEXT,
+        content TEXT,
+        timestamp TIMESTAMP,
+        is_from_me BOOLEAN,
+        media_type TEXT,
+        filename TEXT,
+        url TEXT,
+        media_key BLOB,
+        file_sha256 BLOB,
+        file_enc_sha256 BLOB,
+        file_length INTEGER,
+        PRIMARY KEY (id, chat_jid),
+        FOREIGN KEY (chat_jid) REFERENCES chats(jid)
+    );
+"""
+
+
+def _make_db(path, *, with_read_state: bool):
+    conn = sqlite3.connect(path)
+    cursor = conn.cursor()
+    cursor.executescript((SCHEMA_WITH_READ_STATE if with_read_state else SCHEMA_WITHOUT_READ_STATE) + MESSAGES_SCHEMA)
+    for jid, name, last_message_time, last_read_time, is_from_me in CHATS:
+        if with_read_state:
+            cursor.execute(
+                "INSERT INTO chats (jid, name, last_message_time, last_read_time) VALUES (?, ?, ?, ?)",
+                (jid, name, last_message_time, last_read_time),
+            )
+        else:
+            cursor.execute(
+                "INSERT INTO chats (jid, name, last_message_time) VALUES (?, ?, ?)",
+                (jid, name, last_message_time),
+            )
+        cursor.execute(
+            """INSERT INTO messages (id, chat_jid, sender, content, timestamp, is_from_me)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (f"msg-{jid}", jid, "me" if is_from_me else jid, "hello", last_message_time, is_from_me),
+        )
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture
+def read_state_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "messages.db"
+    _make_db(str(db_path), with_read_state=True)
+    monkeypatch.setattr(whatsapp, "MESSAGES_DB_PATH", str(db_path))
+    return db_path
+
+
+@pytest.fixture
+def legacy_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "legacy.db"
+    _make_db(str(db_path), with_read_state=False)
+    monkeypatch.setattr(whatsapp, "MESSAGES_DB_PATH", str(db_path))
+    return db_path
+
+
+@pytest.mark.parametrize("include_last_message", [True, False])
+def test_list_chats_exposes_read_state(read_state_db, include_last_message):
+    chats = {c["jid"]: c for c in whatsapp.list_chats(limit=10, include_last_message=include_last_message)}
+
+    assert chats["unread@s.whatsapp.net"]["last_read_time"] == "2024-01-15T09:00:00+00:00"
+    assert chats["unread@s.whatsapp.net"]["unread"] is True
+    # Read on another device after the last message arrived.
+    assert chats["read@s.whatsapp.net"]["last_read_time"] == "2024-01-15T11:00:00+00:00"
+    assert chats["read@s.whatsapp.net"]["unread"] is False
+    # Our own message can never be unread, marker or not.
+    assert chats["mine@s.whatsapp.net"]["last_read_time"] is None
+    assert chats["mine@s.whatsapp.net"]["unread"] is False
+    # No marker: falls back to "last message is inbound".
+    assert chats["nomarker@s.whatsapp.net"]["last_read_time"] is None
+    assert chats["nomarker@s.whatsapp.net"]["unread"] is True
+
+
+@pytest.mark.parametrize("include_last_message", [True, False])
+def test_get_chat_exposes_read_state(read_state_db, include_last_message):
+    chat = whatsapp.get_chat("read@s.whatsapp.net", include_last_message=include_last_message)
+    assert chat["last_read_time"] == "2024-01-15T11:00:00+00:00"
+    assert chat["unread"] is False
+
+    chat = whatsapp.get_chat("unread@s.whatsapp.net", include_last_message=include_last_message)
+    assert chat["last_read_time"] == "2024-01-15T09:00:00+00:00"
+    assert chat["unread"] is True
+
+
+def test_get_direct_chat_by_contact_exposes_read_state(read_state_db):
+    chat = whatsapp.get_direct_chat_by_contact("unread")
+    assert chat["last_read_time"] == "2024-01-15T09:00:00+00:00"
+    assert chat["unread"] is True
+
+
+def test_get_contact_chats_exposes_read_state(read_state_db):
+    chats = whatsapp.get_contact_chats("read@s.whatsapp.net")
+    chat = next(c for c in chats if c["jid"] == "read@s.whatsapp.net")
+    assert chat["last_read_time"] == "2024-01-15T11:00:00+00:00"
+    assert chat["unread"] is False
+
+
+def test_reads_work_against_store_without_read_state_column(legacy_db):
+    """A messages.db from a bridge older than the migration must still read."""
+    chats = {c["jid"]: c for c in whatsapp.list_chats(limit=10)}
+    assert len(chats) == len(CHATS)
+    assert all(c["last_read_time"] is None for c in chats.values())
+    assert chats["unread@s.whatsapp.net"]["unread"] is True
+    assert chats["mine@s.whatsapp.net"]["unread"] is False
+
+    chat = whatsapp.get_chat("read@s.whatsapp.net")
+    assert chat["last_read_time"] is None
+    assert chat["unread"] is True

--- a/whatsapp-mcp-server/whatsapp.py
+++ b/whatsapp-mcp-server/whatsapp.py
@@ -71,11 +71,30 @@ class Chat:
     last_message: str | None = None
     last_sender: str | None = None
     last_is_from_me: bool | None = None
+    # Bridge read marker (chats.last_read_time): how far we have read this
+    # chat, from read receipts and history-sync backfill. NULL when the
+    # bridge has never seen a read for the chat, or predates the column.
+    last_read_time: datetime | None = None
 
     @property
     def is_group(self) -> bool:
         """Determine if chat is a group based on JID pattern."""
         return self.jid.endswith("@g.us")
+
+    @property
+    def unread(self) -> bool:
+        """Whether the chat's last message is inbound and unread by us.
+
+        With a read marker this is genuine unread — a chat read on the phone
+        or another linked device is not reported. Without one (older bridge,
+        or a chat WhatsApp never reported a read for) it degrades to the old
+        heuristic: unread if the last message is inbound.
+        """
+        if self.last_message_time is None or self.last_is_from_me:
+            return False
+        if self.last_read_time is None:
+            return True
+        return self.last_message_time > self.last_read_time
 
 
 @dataclass
@@ -140,12 +159,25 @@ def chat_to_dict(chat: "Chat") -> dict[str, Any]:
         "last_message": chat.last_message,
         "last_sender": chat.last_sender,
         "last_is_from_me": chat.last_is_from_me,
+        "last_read_time": chat.last_read_time.isoformat() if chat.last_read_time else None,
+        "unread": chat.unread,
     }
 
 
 def contact_to_dict(contact: "Contact") -> dict[str, Any]:
     """Convert a Contact dataclass to a dictionary for JSON serialization."""
     return {"phone_number": contact.phone_number, "name": contact.name, "jid": contact.jid}
+
+
+def _last_read_time_select(cursor: sqlite3.Cursor, table_alias: str) -> str:
+    """SELECT expression for chats.last_read_time, or a NULL literal.
+
+    The bridge adds the column through its own migration, so a messages.db
+    written by an older bridge doesn't have it yet. Reads must keep working
+    against such a store — those chats simply report last_read_time = None.
+    """
+    columns = {row[1] for row in cursor.execute("PRAGMA table_info(chats)").fetchall()}
+    return f"{table_alias}.last_read_time" if "last_read_time" in columns else "NULL"
 
 
 def _sender_aliases(value: str) -> list[str]:
@@ -610,19 +642,14 @@ def list_chats(
         conn = sqlite3.connect(MESSAGES_DB_PATH)
         cursor = conn.cursor()
 
-        # Build base query. The last-message columns are referenced by tuple
-        # index downstream, so we keep the result shape constant and emit
-        # static NULLs when the messages table is not joined — otherwise the
-        # SELECT references messages.* with no FROM/JOIN and SQLite errors
-        # out with "no such column: messages.content".
+        # The last message is always joined — is_from_me feeds the unread
+        # flag — but its content is only selected when asked for. The columns
+        # are referenced by tuple index downstream, so the result shape stays
+        # constant across the branch.
         if include_last_message:
-            last_message_select = (
-                "messages.content as last_message, "
-                "messages.sender as last_sender, "
-                "messages.is_from_me as last_is_from_me"
-            )
+            last_message_select = "messages.content as last_message, messages.sender as last_sender"
         else:
-            last_message_select = "NULL as last_message, NULL as last_sender, NULL as last_is_from_me"
+            last_message_select = "NULL as last_message, NULL as last_sender"
 
         query_parts = [
             f"""
@@ -630,16 +657,14 @@ def list_chats(
                 chats.jid,
                 chats.name,
                 chats.last_message_time,
-                {last_message_select}
+                {last_message_select},
+                messages.is_from_me as last_is_from_me,
+                {_last_read_time_select(cursor, "chats")}
             FROM chats
+            LEFT JOIN messages ON chats.jid = messages.chat_jid
+                AND chats.last_message_time = messages.timestamp
         """
         ]
-
-        if include_last_message:
-            query_parts.append("""
-                LEFT JOIN messages ON chats.jid = messages.chat_jid
-                AND chats.last_message_time = messages.timestamp
-            """)
 
         where_clauses = []
         params = []
@@ -675,6 +700,7 @@ def list_chats(
                 last_message=chat_data[3],
                 last_sender=chat_data[4],
                 last_is_from_me=chat_data[5],
+                last_read_time=datetime.fromisoformat(chat_data[6]) if chat_data[6] else None,
             )
             result.append(chat_to_dict(chat))
 
@@ -783,7 +809,8 @@ def get_contact_chats(jid: str, limit: int = 20, page: int = 0) -> list[dict[str
                 c.last_message_time,
                 last_msg.content as last_message,
                 last_msg.sender as last_sender,
-                last_msg.is_from_me as last_is_from_me
+                last_msg.is_from_me as last_is_from_me,
+                {_last_read_time_select(cursor, "c")}
             FROM chats c
             LEFT JOIN messages last_msg ON c.jid = last_msg.chat_jid
                 AND c.last_message_time = last_msg.timestamp
@@ -810,6 +837,7 @@ def get_contact_chats(jid: str, limit: int = 20, page: int = 0) -> list[dict[str
                 last_message=chat_data[3],
                 last_sender=chat_data[4],
                 last_is_from_me=chat_data[5],
+                last_read_time=datetime.fromisoformat(chat_data[6]) if chat_data[6] else None,
             )
             result.append(chat_to_dict(chat))
 
@@ -894,30 +922,26 @@ def get_chat(chat_jid: str, include_last_message: bool = True) -> dict[str, Any]
         conn = sqlite3.connect(MESSAGES_DB_PATH)
         cursor = conn.cursor()
 
-        # See list_chats: keep result tuple shape stable across the
-        # include_last_message branch by emitting static NULLs when we
-        # don't JOIN the messages table.
+        # See list_chats: the last message is always joined for is_from_me,
+        # and the result tuple shape stays stable across the branch.
         if include_last_message:
-            last_message_select = "m.content as last_message, m.sender as last_sender, m.is_from_me as last_is_from_me"
+            last_message_select = "m.content as last_message, m.sender as last_sender"
         else:
-            last_message_select = "NULL as last_message, NULL as last_sender, NULL as last_is_from_me"
+            last_message_select = "NULL as last_message, NULL as last_sender"
 
         query = f"""
             SELECT
                 c.jid,
                 c.name,
                 c.last_message_time,
-                {last_message_select}
+                {last_message_select},
+                m.is_from_me as last_is_from_me,
+                {_last_read_time_select(cursor, "c")}
             FROM chats c
-        """
-
-        if include_last_message:
-            query += """
-                LEFT JOIN messages m ON c.jid = m.chat_jid
+            LEFT JOIN messages m ON c.jid = m.chat_jid
                 AND c.last_message_time = m.timestamp
-            """
-
-        query += " WHERE c.jid = ?"
+            WHERE c.jid = ?
+        """
 
         cursor.execute(query, (chat_jid,))
         chat_data = cursor.fetchone()
@@ -932,6 +956,7 @@ def get_chat(chat_jid: str, include_last_message: bool = True) -> dict[str, Any]
             last_message=chat_data[3],
             last_sender=chat_data[4],
             last_is_from_me=chat_data[5],
+            last_read_time=datetime.fromisoformat(chat_data[6]) if chat_data[6] else None,
         )
         return chat_to_dict(chat)
 
@@ -950,14 +975,15 @@ def get_direct_chat_by_contact(sender_phone_number: str) -> dict[str, Any] | Non
         cursor = conn.cursor()
 
         cursor.execute(
-            """
+            f"""
             SELECT
                 c.jid,
                 c.name,
                 c.last_message_time,
                 m.content as last_message,
                 m.sender as last_sender,
-                m.is_from_me as last_is_from_me
+                m.is_from_me as last_is_from_me,
+                {_last_read_time_select(cursor, "c")}
             FROM chats c
             LEFT JOIN messages m ON c.jid = m.chat_jid
                 AND c.last_message_time = m.timestamp
@@ -979,6 +1005,7 @@ def get_direct_chat_by_contact(sender_phone_number: str) -> dict[str, Any] | Non
             last_message=chat_data[3],
             last_sender=chat_data[4],
             last_is_from_me=chat_data[5],
+            last_read_time=datetime.fromisoformat(chat_data[6]) if chat_data[6] else None,
         )
         return chat_to_dict(chat)
 


### PR DESCRIPTION
Closes #194

## What & why

The bridge's `messages.db` has no notion of read state, so consumers can only approximate "unread" as *the latest message in a chat is inbound* — which surfaces long-dead one-sided threads and anything already read on another device. This adds a `chats.last_read_time` marker and exposes it (plus a derived `unread` flag) through the MCP chat tools, so clients can distinguish genuine unread from "latest message is inbound".

## How

### Bridge — write path

Two sources populate a single monotonic `chats.last_read_time`:

1. **Read receipts (going forward).** A new `*events.Receipt` handler records *self*-reads — DM reads arrive as `read-self`, group reads as `read` with `IsFromMe` (the participant is us). It resolves the receipt's `@lid` chat to the phone JID via the existing `resolveLIDChat` helper (receipts carry no phone-JID alt, so this leans on its `LIDs.GetPNForLID` fallback), so the marker key matches the message rows.

2. **History-sync backfill (existing chats).** In the existing `handleHistorySync` conversation loop, a conversation WhatsApp reports as fully read (`GetUnreadCount() == 0 && !GetMarkedAsUnread()`) is marked read up to its last message.

`MarkChatRead` merges the marker **monotonically** — mirroring `StoreChat`'s existing `last_message_time` merge — so out-of-order receipts and late history-sync chunks can never move it backwards and un-read a chat. The column is added through the existing `ensureColumn` migration, so existing stores upgrade in place.

### MCP — read path

Every chat tool (`list_chats`, `get_chat`, `get_direct_chat_by_contact`, `get_contact_chats`) returns two new fields:

```jsonc
{
  // …existing fields…
  "last_read_time": "2024-01-15T09:00:00+00:00", // the marker, null if never reported
  "unread": true                                 // last message is inbound and newer than the marker
}
```

`unread` is derived on the Python side (`Chat.unread`): a chat whose last message is ours is never unread, and a chat with no marker degrades to the old "last message is inbound" heuristic. To make that work in both modes, `list_chats`/`get_chat` now always join the last message for `is_from_me`; `include_last_message` still gates its content/sender.

**Backward compatibility:** a `messages.db` written by a bridge older than the migration has no `last_read_time` column. The read path detects that (`PRAGMA table_info`) and selects a NULL literal instead, so an un-upgraded store keeps working and simply reports `last_read_time: null`.

Documented in `README.md` (chat response shape + a "Read state" section with the caveats) and in the `list_chats`/`get_chat` tool docstrings.

## Known limitation

Because the marker only advances, manually marking an already-read chat as *unread* on the phone isn't reflected. It's uncommon, and monotonicity is what keeps the marker idempotent and race-safe. A future `marked_unread` column could add it.

## Tests

- **Go** (`main_test.go`): the monotonic merge (`MarkChatRead` sets when absent, advances on a newer read, never regresses on an older one) and the self-read classification (`isSelfReadReceipt` across read-self / group-read-by-us / other-user-read-our-message / delivered / sender).
- **Python** (`tests/test_read_state.py`): end-to-end read path over a real SQLite store — `last_read_time` and `unread` across all four chat tools and both `include_last_message` modes, covering unread, read-elsewhere, last-message-is-ours, and no-marker chats, plus a store with no `last_read_time` column at all.

Full bridge suite, `go vet`, `go build`, `pytest` (76 passed), and `ruff check`/`format` pass.

## Notes

Verified against a live linked account that read receipts arrive and resolve to the correct phone JID.
