### PR TITLE
feat(mcp): add @-mention support to send_message

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Send a text message to a contact or group, optionally as a quoted reply.
 - `quoted_message_id` (optional): ID of the message to reply to. When provided, the sent message appears as a quoted reply in WhatsApp.
 - `quoted_sender_jid` (optional): Full JID of the author of the quoted message. Required for group replies so WhatsApp renders the correct attribution header.
 - `quoted_content` (optional): Text content of the quoted message, used for the reply preview. Only plain text is supported.
+- `mentions` (optional): List of users to @-mention, as phone numbers with country code (e.g. `["12025551234"]`) or JIDs. For each entry the message text must contain a matching `@<number>` token (e.g. `"thanks @12025551234!"`), which recipients' devices render as a highlighted, tappable mention that also notifies the user. Only meaningful in group chats.
 
 Inbound quoted replies are stored automatically. The `quoted_message_id` field in each message returned by `list_messages` indicates which message it is replying to (or `null` for non-replies).
 

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -922,6 +922,10 @@ type SendMessageRequest struct {
 	QuotedMessageID string `json:"quoted_message_id,omitempty"`
 	QuotedSenderJID string `json:"quoted_sender_jid,omitempty"`
 	QuotedContent   string `json:"quoted_content,omitempty"`
+	// Mentions lists users to @-mention (phone numbers or JIDs). The message
+	// text must contain a matching "@<number>" token for each entry, or the
+	// mention won't render on recipients' devices.
+	Mentions []string `json:"mentions,omitempty"`
 }
 
 // ReactRequest is the request body for the /api/react endpoint.
@@ -1141,11 +1145,41 @@ func resolveRecipientJID(client *whatsmeow.Client, recipient string) (types.JID,
 	return recipientJID, nil
 }
 
+// resolveMentionJIDs maps mention entries (phone numbers or JIDs) to the JID
+// strings WhatsApp expects in ContextInfo.MentionedJID. Phone-number entries
+// contribute both the phone JID and, when known, its LID form so the mention
+// renders regardless of the group's addressing mode.
+func resolveMentionJIDs(client *whatsmeow.Client, mentions []string) []string {
+	var resolved []string
+	for _, mention := range mentions {
+		var jid types.JID
+		if strings.Contains(mention, "@") {
+			parsed, err := types.ParseJID(mention)
+			if err != nil {
+				fmt.Printf("Warning: skipping unparseable mention %q: %v\n", mention, err)
+				continue
+			}
+			jid = parsed
+		} else {
+			jid = types.JID{User: mention, Server: types.DefaultUserServer}
+		}
+		resolved = append(resolved, jid.String())
+		if jid.Server == types.DefaultUserServer {
+			if lid, err := client.Store.LIDs.GetLIDForPN(context.Background(), jid); err == nil && !lid.IsEmpty() {
+				resolved = append(resolved, lid.String())
+			}
+		}
+	}
+	return resolved
+}
+
 // Function to send a WhatsApp message
-func sendWhatsAppMessage(client *whatsmeow.Client, messageStore *MessageStore, recipient string, message string, mediaPath string, quotedMsgID string, quotedSenderJID string, quotedContent string) (bool, string) {
+func sendWhatsAppMessage(client *whatsmeow.Client, messageStore *MessageStore, recipient string, message string, mediaPath string, quotedMsgID string, quotedSenderJID string, quotedContent string, mentions []string) (bool, string) {
 	if !client.IsConnected() {
 		return false, "Not connected to WhatsApp"
 	}
+
+	mentionedJIDs := resolveMentionJIDs(client, mentions)
 
 	var settingsLookupJID types.JID
 	var err error
@@ -1261,22 +1295,37 @@ func sendWhatsAppMessage(client *whatsmeow.Client, messageStore *MessageStore, r
 				FileLength:    &resp.FileLength,
 			}
 		}
-	} else if quotedMsgID != "" {
-		// Quoted reply: use ExtendedTextMessage so we can attach ContextInfo.
-		// Only text quoting is supported; quoting media messages is not exposed
-		// because the quoted preview on the recipient's device requires the
-		// original media's key/URL, which is not available to the API caller.
-		ctx := &waProto.ContextInfo{
-			StanzaID:      proto.String(quotedMsgID),
-			Participant:   proto.String(quotedSenderJID),
-			QuotedMessage: &waProto.Message{Conversation: proto.String(quotedContent)},
+	} else if quotedMsgID != "" || len(mentionedJIDs) > 0 {
+		// Quoted reply and/or mentions: use ExtendedTextMessage so we can
+		// attach ContextInfo. Only text quoting is supported; quoting media
+		// messages is not exposed because the quoted preview on the
+		// recipient's device requires the original media's key/URL, which is
+		// not available to the API caller.
+		ctx := &waProto.ContextInfo{}
+		if quotedMsgID != "" {
+			ctx.StanzaID = proto.String(quotedMsgID)
+			ctx.Participant = proto.String(quotedSenderJID)
+			ctx.QuotedMessage = &waProto.Message{Conversation: proto.String(quotedContent)}
 		}
+		ctx.MentionedJID = mentionedJIDs
 		msg.ExtendedTextMessage = &waProto.ExtendedTextMessage{
 			Text:        proto.String(message),
 			ContextInfo: ctx,
 		}
 	} else {
 		msg.Conversation = proto.String(message)
+	}
+
+	// Mentions in media captions live on the media message's own ContextInfo.
+	if len(mentionedJIDs) > 0 {
+		switch {
+		case msg.ImageMessage != nil:
+			msg.ImageMessage.ContextInfo = &waProto.ContextInfo{MentionedJID: mentionedJIDs}
+		case msg.VideoMessage != nil:
+			msg.VideoMessage.ContextInfo = &waProto.ContextInfo{MentionedJID: mentionedJIDs}
+		case msg.DocumentMessage != nil:
+			msg.DocumentMessage.ContextInfo = &waProto.ContextInfo{MentionedJID: mentionedJIDs}
+		}
 	}
 
 	// Normalize @lid recipients to phone JID before the lookup. Chats are
@@ -2017,7 +2066,7 @@ func newRESTMux(client *whatsmeow.Client, messageStore *MessageStore, port int, 
 			req.Recipient, len(req.Message), resolvedMediaPath != "")
 
 		// Send the message
-		success, message := sendWhatsAppMessage(client, messageStore, req.Recipient, req.Message, resolvedMediaPath, req.QuotedMessageID, req.QuotedSenderJID, req.QuotedContent)
+		success, message := sendWhatsAppMessage(client, messageStore, req.Recipient, req.Message, resolvedMediaPath, req.QuotedMessageID, req.QuotedSenderJID, req.QuotedContent, req.Mentions)
 		fmt.Printf("← /api/send success=%v status=%q\n", success, message)
 		// Set response headers
 		w.Header().Set("Content-Type", "application/json")

--- a/whatsapp-bridge/main_test.go
+++ b/whatsapp-bridge/main_test.go
@@ -2424,3 +2424,79 @@ func TestNewMessageStoreCreatesMessagesChatJIDIndex(t *testing.T) {
 		t.Fatalf("expected idx_messages_chat_jid to exist, found %d", count)
 	}
 }
+
+// TestResolveMentionJIDs verifies mapping of mention entries to the JID
+// strings placed in ContextInfo.MentionedJID, including the dual phone+LID
+// form for LID-addressed groups.
+func TestResolveMentionJIDs(t *testing.T) {
+	phonePN := types.JID{User: "12025551234", Server: types.DefaultUserServer}
+	phoneLID := types.JID{User: "111222333444555", Server: types.HiddenUserServer}
+	lidStore := &mockLIDStore{lidByPN: map[types.JID]types.JID{phonePN: phoneLID}}
+	client := newTestClient(lidStore)
+
+	cases := []struct {
+		name     string
+		mentions []string
+		want     []string
+	}{
+		{
+			"phone number with LID mapping yields both forms",
+			[]string{"12025551234"},
+			[]string{phonePN.String(), phoneLID.String()},
+		},
+		{
+			"phone number without LID mapping yields phone JID only",
+			[]string{"19998887777"},
+			[]string{"19998887777@" + types.DefaultUserServer},
+		},
+		{
+			"explicit LID JID passed through unchanged",
+			[]string{phoneLID.String()},
+			[]string{phoneLID.String()},
+		},
+		{
+			"unparseable entry skipped",
+			[]string{"1.2.3@s.whatsapp.net", "12025551234"},
+			[]string{phonePN.String(), phoneLID.String()},
+		},
+		{
+			"empty input yields nil",
+			nil,
+			nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveMentionJIDs(client, tc.mentions)
+			if len(got) != len(tc.want) {
+				t.Fatalf("resolveMentionJIDs(%v) = %v, want %v", tc.mentions, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("resolveMentionJIDs(%v)[%d] = %q, want %q", tc.mentions, i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestSendHandler_MentionsField_PassedThrough proves the mentions JSON field
+// is parsed by /api/send — mirrors the quoted-reply field test above.
+func TestSendHandler_MentionsField_PassedThrough(t *testing.T) {
+	const token = "supersecrettoken1234567890abcdef"
+	handler := newRESTMux(newTestClient(&mockLIDStore{}), newTestMessageStore(t), 8080, token, nil)
+
+	// POST with mentions but no recipient — should 400 before any send
+	// attempt, proving the new field parses without error.
+	body := `{"recipient":"","message":"hi @12025551234","mentions":["12025551234"]}`
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:8080/api/send", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for empty recipient with mentions field, got %d", resp.Code)
+	}
+}

--- a/whatsapp-mcp-server/main.py
+++ b/whatsapp-mcp-server/main.py
@@ -307,6 +307,7 @@ def send_message(
     quoted_message_id: str = "",
     quoted_sender_jid: str = "",
     quoted_content: str = "",
+    mentions: list[str] | None = None,
 ) -> dict[str, Any]:
     """Send a WhatsApp message to a person or group. For group chats use the JID.
 
@@ -320,6 +321,10 @@ def send_message(
                            group replies so WhatsApp renders the correct attribution.
         quoted_content: Text content of the quoted message, used for the reply preview.
                         Only plain text is supported; media previews are not included.
+        mentions: Users to @-mention, as phone numbers with country code but no + (e.g.
+                  ["420601234567"]) or JIDs. For each entry the message text must contain
+                  a matching "@<number>" token (e.g. "hi @420601234567"), otherwise the
+                  mention won't render on recipients' devices. Only meaningful in groups.
 
     Returns:
         A dictionary containing success status and a status message
@@ -330,7 +335,7 @@ def send_message(
 
     # Call the whatsapp_send_message function with the unified recipient parameter
     success, status_message = whatsapp_send_message(
-        recipient, message, quoted_message_id, quoted_sender_jid, quoted_content
+        recipient, message, quoted_message_id, quoted_sender_jid, quoted_content, mentions
     )
     return {"success": success, "message": status_message}
 

--- a/whatsapp-mcp-server/tests/test_bridge_auth.py
+++ b/whatsapp-mcp-server/tests/test_bridge_auth.py
@@ -211,3 +211,42 @@ def test_send_message_without_quote_omits_quote_fields(monkeypatch):
     assert "quoted_message_id" not in payload
     assert "quoted_sender_jid" not in payload
     assert "quoted_content" not in payload
+
+
+def test_send_message_with_mentions_includes_mentions_field(monkeypatch):
+    """send_message passes the mentions list to /api/send."""
+    calls = []
+    monkeypatch.setenv("WHATSAPP_BRIDGE_TOKEN", "test-token")
+
+    def fake_post(url, json, headers=None):
+        calls.append({"url": url, "json": json})
+        return DummyResponse()
+
+    monkeypatch.setattr(whatsapp.requests, "post", fake_post)
+
+    success, _ = whatsapp.send_message(
+        "123456789@g.us",
+        "thanks @12025551234!",
+        mentions=["12025551234"],
+    )
+
+    assert success is True
+    payload = calls[0]["json"]
+    assert payload["mentions"] == ["12025551234"]
+
+
+def test_send_message_without_mentions_omits_mentions_field(monkeypatch):
+    """send_message without mentions does not include the mentions field."""
+    calls = []
+    monkeypatch.setenv("WHATSAPP_BRIDGE_TOKEN", "test-token")
+
+    def fake_post(url, json, headers=None):
+        calls.append({"url": url, "json": json})
+        return DummyResponse()
+
+    monkeypatch.setattr(whatsapp.requests, "post", fake_post)
+
+    whatsapp.send_message("12025551234@s.whatsapp.net", "Hello!")
+
+    payload = calls[0]["json"]
+    assert "mentions" not in payload

--- a/whatsapp-mcp-server/whatsapp.py
+++ b/whatsapp-mcp-server/whatsapp.py
@@ -996,6 +996,7 @@ def send_message(
     quoted_message_id: str = "",
     quoted_sender_jid: str = "",
     quoted_content: str = "",
+    mentions: list[str] | None = None,
 ) -> tuple[bool, str]:
     try:
         # Validate input
@@ -1011,6 +1012,8 @@ def send_message(
             payload["quoted_message_id"] = quoted_message_id
             payload["quoted_sender_jid"] = quoted_sender_jid
             payload["quoted_content"] = quoted_content
+        if mentions:
+            payload["mentions"] = mentions
 
         response = requests.post(url, json=payload, headers=_bridge_headers())
 


### PR DESCRIPTION
## Summary

- Adds an optional `mentions` field to `/api/send` and a matching `mentions: list[str] | None` parameter on the `send_message` MCP tool, so agents can send real WhatsApp @-mentions — highlighted, tappable, and notifying — instead of plain `@number` text that renders literally and notifies no one.
- Mentions are attached as `ContextInfo.MentionedJID`: plain text goes out as `ExtendedTextMessage` (composing with the existing quoted-reply ContextInfo); image/video/document captions set `MentionedJID` on their own ContextInfo.
- Phone-number entries resolve to **both** the phone JID and, when the LID cache knows the mapping, the LID form (`resolveMentionJIDs`, mirroring `resolveRecipientJID`'s existing LID handling) so mentions render in LID-addressed groups as well as legacy ones.

## Type of change

- [ ] `fix` — bug fix
- [x] `feat` — new feature
- [ ] `chore` / `docs` / `ci` / `refactor` / `test` / `perf`
- [ ] Breaking change (`!` in commit, or `BREAKING CHANGE:` in body)

## Scope check

- [x] This change fits the [`ROADMAP.md`](https://github.com/verygoodplugins/whatsapp-mcp/blob/main/ROADMAP.md) "in scope" list, **or** I've opened an issue first to discuss
- [x] PR is focused on one concern (split if not)
- [x] PR is ≤ ~300 LOC, **or** justified in the description

(186 insertions / 13 deletions across 6 files, tests and docs included. Additive and opt-in: requests without `mentions` are byte-identical to before.)

## Linked issues

Closes #159

## Testing

- [x] Added or updated tests
- [x] Ran `uv run pytest -v` (Python changes) — **43 passed**, including the two new payload tests (`test_send_message_with_mentions_includes_mentions_field`, `test_send_message_without_mentions_omits_mentions_field`, mirroring the quoted-reply pair)
- [x] Ran `golangci-lint run` (v2.7.1 — 0 issues) and `go build ./...` (Go changes); `go test ./...` passes including new `TestResolveMentionJIDs` (5 subtests: phone→phone+LID dual form, cache miss→phone only, explicit LID passthrough, unparseable entry skipped, empty input) and `TestSendHandler_MentionsField_PassedThrough`
- [x] Manually exercised the affected code path — sent mention messages to a real LID-addressed group from a paired bridge; mentions render highlighted with the contact name and trigger a mention notification on the tagged user's device; also verified composition with quoted replies and that messages without `mentions` behave exactly as before

## Docs

- [x] Updated `README.md` (if user-visible) — new `mentions` bullet in the `send_message` parameters section
- [ ] Updated `AGENTS.md` / `CLAUDE.md` (if contributor-visible) — n/a, no contributor-facing workflow change
- [x] Updated tool descriptions in `whatsapp-mcp-server/main.py` (if MCP tools changed) — docstring documents the `@<number>`-token-in-text requirement
- [ ] Updated `.env.example` (if env vars changed) — n/a, no new env vars

## Risk / rollback

- Purely additive, opt-in field: omitting `mentions` leaves the send path unchanged, so existing callers are unaffected.
- The one design decision worth reviewer attention (@edmenendez): `resolveMentionJIDs` includes **both** the phone JID and the LID form per mentioned number. Official clients accept either depending on the group's addressing mode; sending both is harmless where one form is ignored and avoids a per-group addressing-mode lookup. LID resolution reuses the same `client.Store.LIDs.GetLIDForPN` path `resolveRecipientJID` already depends on — no new failure modes; a cache miss degrades to phone-JID-only, which matches today's behavior for legacy groups.
- The `@<number>` token must appear in the message text for clients to render the mention — documented in the tool docstring and README rather than enforced server-side, since WhatsApp itself tolerates `MentionedJID` entries without matching tokens (they simply don't render).
- Rollback: revert the single commit; no schema, env, or config changes.