### PR TITLE
feat(mcp): add transcribe_audio tool for voice messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A Model Context Protocol (MCP) server for WhatsApp, enabling Claude to read and 
 - **Contact Search**: Search contacts by name or phone number with `sender_display` format ("Name (phone)")
 - **Send Messages**: Send text messages to individuals or groups
 - **Media Support**: Send and download images, videos, documents, and voice messages
+- **Voice Transcription**: Transcribe received voice/audio messages to text locally with Whisper (`transcribe_audio`)
 - **Call History**: Capture incoming voice/video calls into a local SQLite table (live, 1:1 and group)
 - **Webhook Integration**: Forward incoming messages to external services
 - **Local Storage**: All messages stored locally in SQLite - only sent to Claude when you allow it
@@ -35,7 +36,8 @@ A Model Context Protocol (MCP) server for WhatsApp, enabling Claude to read and 
 - Python 3.11+
 - [uv](https://docs.astral.sh/uv/) package manager
 - Claude Desktop or Cursor
-- FFmpeg (optional, for voice message conversion)
+- FFmpeg (optional, for voice message conversion and Whisper transcription)
+- [OpenAI Whisper](https://github.com/openai/whisper) CLI (optional, only for `transcribe_audio`; override the binary with `WHISPER_BIN`)
 
 ### Quick Start
 
@@ -269,6 +271,24 @@ Download media from a received message.
 
 - `message_id` (required): ID of the message with media
 - `chat_jid` (required): JID of the chat containing the message
+
+#### `transcribe_audio`
+
+Download a received voice/audio message (if not already cached) and transcribe
+it to text with a local Whisper CLI. Nothing is sent to any external service.
+
+**Parameters:**
+
+- `message_id` (required): ID of the message with the audio
+- `chat_jid` (required): JID of the chat containing the message
+- `language` (optional): Language code such as `pt` or `en`. Defaults to
+  auto-detect, or the `WHISPER_LANGUAGE` env var.
+- `model` (optional): Whisper model such as `base`, `small`, or
+  `large-v3-turbo`. Defaults to the `WHISPER_MODEL` env var (falls back to `base`).
+
+Requires an OpenAI-Whisper-compatible CLI (`whisper` by default; override with
+`WHISPER_BIN`) and FFmpeg on `PATH`. If the CLI is missing, the tool returns a
+clear error instead of failing hard.
 
 ### Chat Operations
 
@@ -580,7 +600,7 @@ flowchart LR
         HEALTH["/api/health"]
     end
 
-    subgraph MCPTools["MCP Tools (14 total)"]
+    subgraph MCPTools["MCP Tools (15 total)"]
         direction TB
         CONT["Contact Tools<br/>search_contacts, get_contact"]
         MSG["Message Tools<br/>list_messages, send_message, etc."]

--- a/whatsapp-mcp-server/main.py
+++ b/whatsapp-mcp-server/main.py
@@ -51,6 +51,9 @@ from whatsapp import (
 from whatsapp import (
     send_reaction as whatsapp_send_reaction,
 )
+from whatsapp import (
+    transcribe_audio as whatsapp_transcribe_audio,
+)
 
 # Initialize FastMCP server. Env-var handling is deferred to the __main__ block
 # so importing this module never parses env vars or exits the process.
@@ -412,6 +415,33 @@ def download_media(message_id: str, chat_jid: str) -> dict[str, Any]:
         return {"success": True, "message": "Media downloaded successfully", "file_path": file_path}
     else:
         return {"success": False, "message": "Failed to download media"}
+
+
+@mcp.tool()
+def transcribe_audio(
+    message_id: str,
+    chat_jid: str,
+    language: str | None = None,
+    model: str | None = None,
+) -> dict[str, Any]:
+    """Transcribe a WhatsApp voice/audio message to text using local Whisper.
+
+    Downloads the audio if it isn't already cached, then runs an OpenAI-Whisper-
+    compatible CLI locally (nothing is sent to any external service). Requires
+    `whisper` (or a compatible CLI set via WHISPER_BIN) and FFmpeg installed.
+
+    Args:
+        message_id: The ID of the message containing the audio
+        chat_jid: The JID of the chat containing the message
+        language: Optional language code (e.g. "pt", "en"). Defaults to auto-detect
+                  or the WHISPER_LANGUAGE env var.
+        model: Optional Whisper model (e.g. "base", "small", "large-v3-turbo").
+               Defaults to the WHISPER_MODEL env var or "base".
+
+    Returns:
+        A dictionary with success status and the transcribed text (or an error message).
+    """
+    return whatsapp_transcribe_audio(message_id, chat_jid, language, model)
 
 
 def shutdown_handler(signum, frame):

--- a/whatsapp-mcp-server/tests/test_transcribe_audio.py
+++ b/whatsapp-mcp-server/tests/test_transcribe_audio.py
@@ -1,0 +1,71 @@
+import os
+
+import whatsapp
+
+
+class DummyCompleted:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_transcribe_audio_whisper_missing(monkeypatch):
+    monkeypatch.setattr(whatsapp.shutil, "which", lambda _bin: None)
+
+    result = whatsapp.transcribe_audio("MSGID", "123@s.whatsapp.net")
+
+    assert result["success"] is False
+    assert "not found on PATH" in result["message"]
+
+
+def test_transcribe_audio_download_failure(monkeypatch):
+    monkeypatch.setattr(whatsapp.shutil, "which", lambda _bin: "/usr/bin/whisper")
+    monkeypatch.setattr(whatsapp, "download_media", lambda _mid, _jid: None)
+
+    result = whatsapp.transcribe_audio("MSGID", "123@s.whatsapp.net")
+
+    assert result["success"] is False
+    assert "download" in result["message"].lower()
+
+
+def test_transcribe_audio_whisper_error(monkeypatch, tmp_path):
+    audio_file = tmp_path / "note.ogg"
+    audio_file.write_bytes(b"fake")
+    monkeypatch.setattr(whatsapp.shutil, "which", lambda _bin: "/usr/bin/whisper")
+    monkeypatch.setattr(whatsapp, "download_media", lambda _mid, _jid: str(audio_file))
+    monkeypatch.setattr(
+        whatsapp.subprocess,
+        "run",
+        lambda *a, **k: DummyCompleted(returncode=1, stderr="boom"),
+    )
+
+    result = whatsapp.transcribe_audio("MSGID", "123@s.whatsapp.net")
+
+    assert result["success"] is False
+    assert "boom" in result["message"]
+
+
+def test_transcribe_audio_success(monkeypatch, tmp_path):
+    audio_file = tmp_path / "note.ogg"
+    audio_file.write_bytes(b"fake")
+    monkeypatch.setattr(whatsapp.shutil, "which", lambda _bin: "/usr/bin/whisper")
+    monkeypatch.setattr(whatsapp, "download_media", lambda _mid, _jid: str(audio_file))
+
+    def fake_run(cmd, capture_output=True, text=True):
+        # Emulate the Whisper CLI writing "<base>.txt" into --output_dir.
+        out_dir = cmd[cmd.index("--output_dir") + 1]
+        base = os.path.splitext(os.path.basename(cmd[1]))[0]
+        with open(os.path.join(out_dir, base + ".txt"), "w", encoding="utf-8") as fh:
+            fh.write("  hello world  \n")
+        return DummyCompleted(returncode=0)
+
+    monkeypatch.setattr(whatsapp.subprocess, "run", fake_run)
+
+    result = whatsapp.transcribe_audio("MSGID", "123@s.whatsapp.net", language="pt", model="small")
+
+    assert result["success"] is True
+    assert result["text"] == "hello world"
+    assert result["model"] == "small"
+    assert result["language"] == "pt"
+    assert result["file_path"] == str(audio_file)

--- a/whatsapp-mcp-server/whatsapp.py
+++ b/whatsapp-mcp-server/whatsapp.py
@@ -1,7 +1,10 @@
 import json
 import os
 import os.path
+import shutil
 import sqlite3
+import subprocess
+import tempfile
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
@@ -1190,3 +1193,97 @@ def download_media(message_id: str, chat_jid: str) -> str | None:
     except Exception as e:
         print(f"Unexpected error: {str(e)}")
         return None
+
+
+# Transcription config via environment variables. The Whisper CLI is an external
+# dependency (not vendored) so installs stay lightweight; override any of these
+# without touching code.
+WHISPER_BIN = os.getenv("WHISPER_BIN", "whisper")
+WHISPER_MODEL = os.getenv("WHISPER_MODEL", "base")
+WHISPER_LANGUAGE = os.getenv("WHISPER_LANGUAGE") or None  # None => auto-detect
+
+
+def transcribe_audio(
+    message_id: str,
+    chat_jid: str,
+    language: str | None = None,
+    model: str | None = None,
+) -> dict[str, Any]:
+    """Download a voice/audio message and transcribe it to text with Whisper.
+
+    Requires an OpenAI-Whisper-compatible CLI on PATH (``whisper`` by default;
+    override with the ``WHISPER_BIN`` env var) and FFmpeg to decode the audio.
+    Model and language default to the ``WHISPER_MODEL`` / ``WHISPER_LANGUAGE``
+    env vars and can be overridden per call.
+
+    Args:
+        message_id: The ID of the message containing the audio.
+        chat_jid: The JID of the chat containing the message.
+        language: Optional language code (e.g. "pt", "en"); None auto-detects.
+        model: Optional Whisper model name (e.g. "base", "small", "large-v3-turbo").
+
+    Returns:
+        On success: ``{"success": True, "text": ..., "model": ..., "language": ...,
+        "file_path": ...}``. On failure: ``{"success": False, "message": ...}``.
+    """
+    whisper_bin = shutil.which(WHISPER_BIN)
+    if not whisper_bin:
+        return {
+            "success": False,
+            "message": (
+                f"Whisper CLI '{WHISPER_BIN}' not found on PATH. Install openai-whisper "
+                "(`pip install -U openai-whisper`) or set the WHISPER_BIN env var."
+            ),
+        }
+
+    file_path = download_media(message_id, chat_jid)
+    if not file_path:
+        return {"success": False, "message": "Could not download the audio message to transcribe."}
+
+    use_model = model or WHISPER_MODEL
+    use_language = language or WHISPER_LANGUAGE
+
+    with tempfile.TemporaryDirectory() as out_dir:
+        cmd = [
+            whisper_bin,
+            file_path,
+            "--model",
+            use_model,
+            "--task",
+            "transcribe",
+            "--output_format",
+            "txt",
+            "--output_dir",
+            out_dir,
+            "--fp16",
+            "False",
+            "--verbose",
+            "False",
+        ]
+        if use_language:
+            cmd += ["--language", use_language]
+
+        try:
+            proc = subprocess.run(cmd, capture_output=True, text=True)
+        except Exception as e:
+            return {"success": False, "message": f"Failed to run Whisper: {e}"}
+
+        if proc.returncode != 0:
+            detail = (proc.stderr or proc.stdout or "").strip()
+            return {"success": False, "message": f"Whisper failed (exit {proc.returncode}): {detail[:500]}"}
+
+        base = os.path.splitext(os.path.basename(file_path))[0]
+        txt_path = os.path.join(out_dir, base + ".txt")
+        try:
+            with open(txt_path, encoding="utf-8") as fh:
+                text = fh.read().strip()
+        except OSError:
+            return {"success": False, "message": "Whisper produced no transcript output."}
+
+    return {
+        "success": True,
+        "text": text,
+        "model": use_model,
+        "language": use_language or "auto",
+        "file_path": file_path,
+    }


### PR DESCRIPTION
## Summary

Adds a `transcribe_audio` MCP tool that downloads a received voice/audio message (if it isn't already cached) and transcribes it to text **locally** with an OpenAI-Whisper-compatible CLI. Nothing is sent to any external service.

Voice-message transcription is one of the most frequently requested features in the ecosystem (see upstream `lharries/whatsapp-mcp#289` and `#290`) and there wasn't a PR for it yet.

## What it does

- New tool: `transcribe_audio(message_id, chat_jid, language=None, model=None)`.
- Reuses the existing `download_media` bridge path, so it inherits this fork's media retry/recovery.
- Dependency-light and configurable — Whisper is an external CLI, **not** vendored, so default installs stay lightweight:
  - `WHISPER_BIN` (default `whisper`), `WHISPER_MODEL` (default `base`), `WHISPER_LANGUAGE` (default: auto-detect)
  - per-call `language` / `model` overrides
- Degrades gracefully: if the Whisper CLI isn't on `PATH`, it returns a clear, actionable error instead of failing hard.

## Tests & checks

- `tests/test_transcribe_audio.py` covers missing-CLI, download-failure, whisper-error, and success paths (fully mocked — no Whisper or bridge required).
- Full suite: **73 passed**. `ruff check .` and `ruff format --check .` are clean.

## Docs

- README: new feature bullet, prerequisites (Whisper + FFmpeg), tool documentation, and updated tool count.

## Notes

- No new runtime dependencies in `pyproject.toml`.
- Verified end-to-end on a live account: downloaded and transcribed a real Portuguese voice note using `large-v3-turbo`.
