### PR TITLE
fix: keep query params in media direct path (403 on all downloads)

### DIFF
--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -1832,10 +1832,8 @@ func extractDirectPathFromURL(url string) string {
 
 	pathPart := parts[1]
 
-	// Remove query parameters
-	pathPart = strings.SplitN(pathPart, "?", 2)[0]
-
-	// Create proper direct path format
+	// KEEP the query parameters: they carry WhatsApp's auth signature (oh/oe),
+	// and whatsmeow appends its own params with '&', assuming '?' is present.
 	return "/" + pathPart
 }
 


### PR DESCRIPTION
## Problem

Every `/api/download` call fails with **403**, for all media types, fresh or old.

## Root cause

whatsmeow's `DownloadMediaWithPath` constructs the media URL as `https://{host}{directPath}&hash=...&mms-type=...` — it appends its own parameters with `&`, relying on the direct path **retaining its original query string**, which carries WhatsApp's `oh`/`oe` auth signature.

`extractDirectPathFromURL` stripped the query (`strings.SplitN(pathPart, "?", 2)[0]`), producing a malformed, signature-less URL → guaranteed 403.

## Fix

Keep the query string when deriving the direct path. Two-line diff.

## Verification

- `go build` + `go vet` clean
- Live test against a real linked session: a fresh voice note that previously always 403'd downloads successfully; images and documents likewise. History-synced media from before the link still 403s server-side (expected WhatsApp behavior, unrelated to this fix).

## Security note (per AGENTS.md)

This touches download path handling. The derived path remains host-relative and is only ever appended to whatsmeow's `MediaConn` hostnames; no user-controlled host or scheme is introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)