### PR TITLE
fix(bridge): forward native WhatsApp activation metadata

### DIFF
--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"math"
@@ -653,6 +654,24 @@ func (store *MessageStore) GetChatEphemeralSettings(jid string) (ChatEphemeralSe
 		return ChatEphemeralSettings{}, err
 	}
 	return settings, nil
+}
+
+// GetMessageIsFromMe resolves the origin of a stored message for a quoted
+// reply. The boolean pointer distinguishes a known false value from a quote
+// that is absent from the local store.
+func (store *MessageStore) GetMessageIsFromMe(id, chatJID string) (*bool, error) {
+	var isFromMe bool
+	err := store.db.QueryRow(
+		"SELECT is_from_me FROM messages WHERE id = ? AND chat_jid = ?",
+		id, chatJID,
+	).Scan(&isFromMe)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &isFromMe, nil
 }
 
 // Store a message in the database
@@ -1391,6 +1410,32 @@ func extractQuotedMessageInfo(msg *waProto.Message) (quotedMessageId string, quo
 	return quotedMessageId, quotedSender, quotedContent
 }
 
+// extractMentionedJIDs returns native WhatsApp mention targets from ContextInfo.
+func extractMentionedJIDs(msg *waProto.Message) []string {
+	if msg == nil {
+		return nil
+	}
+
+	var contextInfo *waProto.ContextInfo
+	if extText := msg.GetExtendedTextMessage(); extText != nil {
+		contextInfo = extText.GetContextInfo()
+	} else if img := msg.GetImageMessage(); img != nil {
+		contextInfo = img.GetContextInfo()
+	} else if vid := msg.GetVideoMessage(); vid != nil {
+		contextInfo = vid.GetContextInfo()
+	} else if doc := msg.GetDocumentMessage(); doc != nil {
+		contextInfo = doc.GetContextInfo()
+	} else if aud := msg.GetAudioMessage(); aud != nil {
+		contextInfo = aud.GetContextInfo()
+	}
+
+	if contextInfo == nil || len(contextInfo.MentionedJID) == 0 {
+		return nil
+	}
+
+	return append([]string(nil), contextInfo.MentionedJID...)
+}
+
 // Extract media info from a message. Filenames embed the message ID so that
 // two messages arriving in the same second do not collide on a single file.
 func extractMediaInfo(msg *waProto.Message, msgTimestamp time.Time, msgID string) (mediaType string, filename string, url string, mediaKey []byte, fileSHA256 []byte, fileEncSHA256 []byte, fileLength uint64) {
@@ -1605,6 +1650,7 @@ func handleMessage(client *whatsmeow.Client, messageStore *MessageStore, msg *ev
 
 	// Extract quoted message info
 	quotedMessageId, quotedSender, quotedContent := extractQuotedMessageInfo(msg.Message)
+	mentionedJIDs := extractMentionedJIDs(msg.Message)
 
 	// Skip if there's no content and no media
 	if content == "" && mediaType == "" {
@@ -1631,6 +1677,15 @@ func handleMessage(client *whatsmeow.Client, messageStore *MessageStore, msg *ev
 	)
 	if err != nil {
 		logger.Warnf("Failed to store message: %v", err)
+	}
+
+	var quotedIsFromMe *bool
+	if quotedMessageId != "" {
+		var lookupErr error
+		quotedIsFromMe, lookupErr = messageStore.GetMessageIsFromMe(quotedMessageId, chatJID)
+		if lookupErr != nil {
+			logger.Warnf("Failed to resolve quoted message origin: %v", lookupErr)
+		}
 	}
 
 	// For image messages, download media synchronously so we can include the base64
@@ -1688,11 +1743,11 @@ func handleMessage(client *whatsmeow.Client, messageStore *MessageStore, msg *ev
 		if hasImage {
 			SendWebhookWithMedia(
 				sender, content, chatJID, msg.Info.IsFromMe,
-				quotedMessageId, quotedSender, quotedContent,
+				quotedMessageId, quotedSender, quotedContent, quotedIsFromMe, mentionedJIDs,
 				msg.Info.ID, mediaType, imageMimeType, filename, imageDownloadPath,
 			)
 		} else {
-			SendWebhook(sender, content, chatJID, msg.Info.IsFromMe, quotedMessageId, quotedSender, quotedContent)
+			SendWebhook(sender, content, chatJID, msg.Info.IsFromMe, quotedMessageId, quotedSender, quotedContent, quotedIsFromMe, mentionedJIDs)
 		}
 	}
 

--- a/whatsapp-bridge/main_test.go
+++ b/whatsapp-bridge/main_test.go
@@ -2382,6 +2382,39 @@ func TestExtractQuotedMessageInfo_ExtendedText(t *testing.T) {
 	}
 }
 
+func TestExtractMentionedJIDs_ExtendedText(t *testing.T) {
+	msg := &waProto.Message{
+		ExtendedTextMessage: &waProto.ExtendedTextMessage{
+			ContextInfo: &waProto.ContextInfo{
+				MentionedJID: []string{"491742555497@s.whatsapp.net"},
+			},
+		},
+	}
+
+	got := extractMentionedJIDs(msg)
+	if len(got) != 1 || got[0] != "491742555497@s.whatsapp.net" {
+		t.Errorf("mentioned JIDs = %#v", got)
+	}
+}
+
+func TestGetMessageIsFromMe(t *testing.T) {
+	store := newTestMessageStore(t)
+	chatJID := "15551234567@s.whatsapp.net"
+	if err := store.StoreMessage("outbound", chatJID, "15550000000", "[🤖] response", time.Now(), true, "", "", "", nil, nil, nil, 0, ""); err != nil {
+		t.Fatalf("store outbound message: %v", err)
+	}
+
+	isFromMe, err := store.GetMessageIsFromMe("outbound", chatJID)
+	if err != nil || isFromMe == nil || !*isFromMe {
+		t.Fatalf("GetMessageIsFromMe() = %v, %v; want true, nil", isFromMe, err)
+	}
+
+	missing, err := store.GetMessageIsFromMe("missing", chatJID)
+	if err != nil || missing != nil {
+		t.Fatalf("missing lookup = %v, %v; want nil, nil", missing, err)
+	}
+}
+
 // TestExtractQuotedMessageInfo_NoContextInfo verifies graceful handling when
 // the message has no ContextInfo (plain Conversation, ReactionMessage, etc.).
 func TestExtractQuotedMessageInfo_NoContextInfo(t *testing.T) {

--- a/whatsapp-bridge/webhook.go
+++ b/whatsapp-bridge/webhook.go
@@ -51,14 +51,16 @@ var defaultWebhookURL = "http://localhost:8769/whatsapp/webhook"
 
 // WebhookPayload represents the data sent to the webhook
 type WebhookPayload struct {
-	EventType       string `json:"eventType,omitempty"`
-	Sender          string `json:"sender"`
-	Content         string `json:"content"`
-	ChatJID         string `json:"chatJID"`
-	IsFromMe        bool   `json:"isFromMe"`
-	QuotedMessageId string `json:"quotedMessageId,omitempty"`
-	QuotedSender    string `json:"quotedSender,omitempty"`
-	QuotedContent   string `json:"quotedContent,omitempty"`
+	EventType       string   `json:"eventType,omitempty"`
+	Sender          string   `json:"sender"`
+	Content         string   `json:"content"`
+	ChatJID         string   `json:"chatJID"`
+	IsFromMe        bool     `json:"isFromMe"`
+	QuotedMessageId string   `json:"quotedMessageId,omitempty"`
+	QuotedSender    string   `json:"quotedSender,omitempty"`
+	QuotedContent   string   `json:"quotedContent,omitempty"`
+	QuotedIsFromMe  *bool    `json:"quotedIsFromMe,omitempty"`
+	MentionedJIDs   []string `json:"mentionedJids,omitempty"`
 	// Media fields - populated when the message contains an image attachment
 	MessageID     string `json:"messageId,omitempty"`
 	MediaType     string `json:"mediaType,omitempty"`
@@ -117,7 +119,7 @@ func sendWebhookPayload(payload WebhookPayload) {
 }
 
 // SendWebhook sends a text-only message to the webhook endpoint.
-func SendWebhook(sender, content, chatJID string, isFromMe bool, quotedMessageId, quotedSender, quotedContent string) {
+func SendWebhook(sender, content, chatJID string, isFromMe bool, quotedMessageId, quotedSender, quotedContent string, quotedIsFromMe *bool, mentionedJIDs []string) {
 	sendWebhookPayload(WebhookPayload{
 		Sender:          sender,
 		Content:         content,
@@ -126,6 +128,8 @@ func SendWebhook(sender, content, chatJID string, isFromMe bool, quotedMessageId
 		QuotedMessageId: quotedMessageId,
 		QuotedSender:    quotedSender,
 		QuotedContent:   quotedContent,
+		QuotedIsFromMe:  quotedIsFromMe,
+		MentionedJIDs:   mentionedJIDs,
 	})
 }
 
@@ -136,6 +140,7 @@ func SendWebhookWithMedia(
 	sender, content, chatJID string,
 	isFromMe bool,
 	quotedMessageId, quotedSender, quotedContent string,
+	quotedIsFromMe *bool, mentionedJIDs []string,
 	messageID, mediaType, mimeType, mediaFilename, localPath string,
 ) {
 	var mediaBase64 string
@@ -160,6 +165,8 @@ func SendWebhookWithMedia(
 		QuotedMessageId: quotedMessageId,
 		QuotedSender:    quotedSender,
 		QuotedContent:   quotedContent,
+		QuotedIsFromMe:  quotedIsFromMe,
+		MentionedJIDs:   mentionedJIDs,
 		MessageID:       messageID,
 		MediaType:       mediaType,
 		MimeType:        mimeType,

--- a/whatsapp-bridge/webhook_test.go
+++ b/whatsapp-bridge/webhook_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -49,7 +50,7 @@ func TestSendWebhookAttachesBridgeTokenHeader(t *testing.T) {
 	t.Setenv("WEBHOOK_URL", srv.URL)
 	setWebhookAuthToken(t, token)
 
-	SendWebhook("123@s.whatsapp.net", "hello", "123@s.whatsapp.net", false, "", "", "")
+	SendWebhook("123@s.whatsapp.net", "hello", "123@s.whatsapp.net", false, "", "", "", nil, nil)
 
 	if gotToken != token {
 		t.Fatalf("X-Bridge-Token header = %q, want %q", gotToken, token)
@@ -75,7 +76,7 @@ func TestSendWebhookOmitsBridgeTokenHeaderWhenNoToken(t *testing.T) {
 	t.Setenv("WEBHOOK_URL", srv.URL)
 	setWebhookAuthToken(t, "")
 
-	SendWebhook("123@s.whatsapp.net", "hi", "123@s.whatsapp.net", false, "", "", "")
+	SendWebhook("123@s.whatsapp.net", "hi", "123@s.whatsapp.net", false, "", "", "", nil, nil)
 
 	if !received {
 		t.Fatal("webhook was not delivered")
@@ -114,7 +115,7 @@ func TestSendWebhookPreservesURLBasicAuth(t *testing.T) {
 	t.Setenv("WEBHOOK_URL", u.String())
 	setWebhookAuthToken(t, token)
 
-	SendWebhook("123@s.whatsapp.net", "hello", "123@s.whatsapp.net", false, "", "", "")
+	SendWebhook("123@s.whatsapp.net", "hello", "123@s.whatsapp.net", false, "", "", "", nil, nil)
 
 	wantAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte(user+":"+pass))
 	if gotAuth != wantAuth {
@@ -149,7 +150,7 @@ func TestSendWebhookOmitsBridgeTokenOnImplicitDefaultURL(t *testing.T) {
 	setDefaultWebhookURL(t, srv.URL)
 	setWebhookAuthToken(t, token)
 
-	SendWebhook("123@s.whatsapp.net", "hi", "123@s.whatsapp.net", false, "", "", "")
+	SendWebhook("123@s.whatsapp.net", "hi", "123@s.whatsapp.net", false, "", "", "", nil, nil)
 
 	if !received {
 		t.Fatal("webhook was not delivered to the default URL")
@@ -187,12 +188,39 @@ func TestSendWebhookDoesNotFollowRedirects(t *testing.T) {
 	t.Setenv("WEBHOOK_URL", redirector.URL)
 	setWebhookAuthToken(t, token)
 
-	SendWebhook("123@s.whatsapp.net", "hi", "123@s.whatsapp.net", false, "", "", "")
-
+	SendWebhook("123@s.whatsapp.net", "hi", "123@s.whatsapp.net", false, "", "", "", nil, nil)
 	if !redirectHit {
 		t.Fatal("expected the configured webhook URL to be hit")
 	}
 	if targetHit {
 		t.Fatal("bridge must not follow redirects to a different host (would leak X-Bridge-Token)")
+	}
+}
+
+func TestSendWebhookSerializesNativeMentionAndQuotedOrigin(t *testing.T) {
+	var payload WebhookPayload
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() { _ = r.Body.Close() }()
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode webhook payload: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	t.Setenv("WEBHOOK_URL", srv.URL)
+	quotedIsFromMe := true
+	quotedOrigin := &quotedIsFromMe
+	SendWebhook(
+		"123@s.whatsapp.net", "hello", "123@s.whatsapp.net", false,
+		"quoted-id", "456@s.whatsapp.net", "[🤖] prior response",
+		quotedOrigin, []string{"491742555497@s.whatsapp.net"},
+	)
+
+	if payload.QuotedIsFromMe == nil || !*payload.QuotedIsFromMe {
+		t.Fatalf("quotedIsFromMe = %v, want true", payload.QuotedIsFromMe)
+	}
+	if len(payload.MentionedJIDs) != 1 || payload.MentionedJIDs[0] != "491742555497@s.whatsapp.net" {
+		t.Fatalf("mentionedJids = %#v", payload.MentionedJIDs)
 	}
 }


### PR DESCRIPTION
## Summary
- forward native WhatsApp mention JIDs from ContextInfo in inbound webhook payloads
- derive quoted message self-origin from the bridge store using message ID and chat JID
- serialize the trusted quoted-origin metadata and cover extraction, lookup, and payload serialization

## Verification Evidence
- Surface: inbound webhook
- Tier 1: `cd whatsapp-bridge && go test ./...` → `ok whatsapp-client 0.809s`
- Tier 2: AutoHub authenticated self-chat webhook smokes for native mention and verified reply → both `200 {"ok":true,"processed":true,"ignored":false,"denied":false}`; each completed an agent turn
- Red→green: native mention and verified quote metadata are now present on the bridge payload and admitted by AutoHub
- Claim: AutoHub can distinguish native tags and bridge-verified replies to its own WhatsApp messages

## Breaking changes
None. New payload fields are additive: `mentionedJids` and `quotedIsFromMe`.