### PR TITLE
ci: support merge queue checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,6 +7,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- run required CI and security checks for GitHub merge-group refs
- prepare the repository for merge-queue enforcement

## Verification
- `ruby -e "require "yaml"; ARGV.each { |p| YAML.load_file(p) }" .github/workflows/ci.yml .github/workflows/security.yml`
- `git diff --check`

No merge-queue rule is enabled until this workflow support is on `main`.