### PR TITLE
fix(bridge): webhook captionless audio messages

### DIFF
--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -1689,10 +1689,12 @@ func handleMessage(client *whatsmeow.Client, messageStore *MessageStore, msg *ev
 	}
 
 	// For image messages, download media synchronously so we can include the base64
-	// payload in the webhook. Other media types (video, audio, document) are still
-	// downloaded asynchronously since they are not passed to the AI vision pipeline.
+	// payload in the webhook. Audio is also synced so captionless voice notes can be
+	// webhooked the same way. Other media types (video, document) stay async.
 	var imageDownloadPath string
 	var imageMimeType string
+	var audioDownloadPath string
+	var audioMimeType string
 	if mediaType == "image" && url != "" && len(mediaKey) > 0 {
 		logger.Infof("Downloading image media for message %s (synchronous)", msg.Info.ID)
 		success, _, _, dlPath, dlErr := downloadMedia(client, messageStore, msg.Info.ID, chatJID)
@@ -1718,8 +1720,21 @@ func handleMessage(client *whatsmeow.Client, messageStore *MessageStore, msg *ev
 				_, _, _, _, _ = downloadMedia(client, messageStore, msg.Info.ID, chatJID)
 			}()
 		}
-	} else if mediaType != "" && mediaType != "image" && url != "" && len(mediaKey) > 0 {
-		// Non-image media: async download for caching only (not sent to vision pipeline)
+	} else if mediaType == "audio" && url != "" && len(mediaKey) > 0 {
+		logger.Infof("Downloading audio media for message %s (synchronous)", msg.Info.ID)
+		success, _, _, dlPath, dlErr := downloadMedia(client, messageStore, msg.Info.ID, chatJID)
+		if success && dlErr == nil {
+			audioDownloadPath = dlPath
+			audioMimeType = "audio/ogg; codecs=opus"
+			logger.Infof("✅ Audio downloaded: %s", dlPath)
+		} else {
+			logger.Warnf("❌ Audio download failed: %v", dlErr)
+			go func() {
+				_, _, _, _, _ = downloadMedia(client, messageStore, msg.Info.ID, chatJID)
+			}()
+		}
+	} else if mediaType != "" && mediaType != "image" && mediaType != "audio" && url != "" && len(mediaKey) > 0 {
+		// Non-image/non-audio media: async download for caching only
 		logger.Infof("Auto-downloading %s media for message %s", mediaType, msg.Info.ID)
 		go func() {
 			success, _, _, downloadPath, err := downloadMedia(client, messageStore, msg.Info.ID, chatJID)
@@ -1733,18 +1748,24 @@ func handleMessage(client *whatsmeow.Client, messageStore *MessageStore, msg *ev
 
 	// Send webhook for incoming messages.
 	// Forward self-messages when FORWARD_SELF=true.
-	// Always forward image messages (even without a text caption) so the AI vision
-	// pipeline can analyse the image content.
+	// Always forward image and audio messages even without a text caption.
 	shouldForward := forwardSelfMessages || !msg.Info.IsFromMe
 	hasText := content != ""
 	hasImage := mediaType == "image"
+	hasAudio := mediaType == "audio"
 
-	if shouldForward && (hasText || hasImage) {
+	if shouldForward && (hasText || hasImage || hasAudio) {
 		if hasImage {
 			SendWebhookWithMedia(
 				sender, content, chatJID, msg.Info.IsFromMe,
 				quotedMessageId, quotedSender, quotedContent, quotedIsFromMe, mentionedJIDs,
 				msg.Info.ID, mediaType, imageMimeType, filename, imageDownloadPath,
+			)
+		} else if hasAudio {
+			SendWebhookWithMedia(
+				sender, content, chatJID, msg.Info.IsFromMe,
+				quotedMessageId, quotedSender, quotedContent, quotedIsFromMe, mentionedJIDs,
+				msg.Info.ID, mediaType, audioMimeType, filename, audioDownloadPath,
 			)
 		} else {
 			SendWebhook(sender, content, chatJID, msg.Info.IsFromMe, quotedMessageId, quotedSender, quotedContent, quotedIsFromMe, mentionedJIDs)

--- a/whatsapp-bridge/main_test.go
+++ b/whatsapp-bridge/main_test.go
@@ -1417,6 +1417,55 @@ func captureRawWebhook(t *testing.T) (*httptest.Server, <-chan map[string]any) {
 // TestHandleMessage_ImageOnly_WebhookForwarded verifies that an image message
 // with no text caption is forwarded to the webhook endpoint (not silently
 // dropped), and that the webhook payload contains the expected media fields.
+func buildAudioMessage(chat, sender types.JID, isFromMe bool) *events.Message {
+	return &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Chat:     chat,
+				Sender:   sender,
+				IsFromMe: isFromMe,
+			},
+			ID:        "test-aud-001",
+			Timestamp: time.Now(),
+		},
+		// No URL/mediaKey: download is skipped; webhook should still fire.
+		Message: &waProto.Message{AudioMessage: &waProto.AudioMessage{}},
+	}
+}
+
+func TestHandleMessage_AudioOnly_WebhookForwarded(t *testing.T) {
+	srv, webhookCh := captureWebhook(t)
+	t.Setenv("WEBHOOK_URL", srv.URL)
+
+	client := newTestClient(&mockLIDStore{})
+	ms := newTestMessageStore(t)
+	logger := testLogger()
+
+	msg := buildAudioMessage(phonePN, phonePN, false)
+	handleMessage(client, ms, msg, logger)
+
+	if count := queryMessageCount(ms, phonePN.String()); count != 1 {
+		t.Errorf("expected 1 message stored, got %d", count)
+	}
+
+	select {
+	case payload := <-webhookCh:
+		if payload.MediaType != "audio" {
+			t.Errorf("expected mediaType=audio, got %q", payload.MediaType)
+		}
+		if payload.MessageID != "test-aud-001" {
+			t.Errorf("expected messageId=test-aud-001, got %q", payload.MessageID)
+		}
+		if payload.Content != "" {
+			t.Errorf("expected empty content for audio-only message, got %q", payload.Content)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for webhook call")
+	}
+}
+
+// TestHandleMessage_Contact_WebhookForwarded verifies contact/vCard shares are
+// stored and webhooked with a text summary and mediaType=contact.
 func TestHandleMessage_ImageOnly_WebhookForwarded(t *testing.T) {
 	srv, webhookCh := captureWebhook(t)
 	t.Setenv("WEBHOOK_URL", srv.URL)


### PR DESCRIPTION
## Summary

- Captionless audio/PTT was auto-downloaded but never webhooked (forwarding required text or image).
- Sync-download audio the same way as images, then call `SendWebhookWithMedia` when `mediaType` is `audio`.

## Type of change

- [x] `fix` — bug fix
- [ ] `feat` — new feature
- [ ] `chore` / `docs` / `ci` / `refactor` / `test` / `perf`
- [ ] Breaking change (`!` in commit, or `BREAKING CHANGE:` in body)

## Scope check

- [x] This change fits the [`ROADMAP.md`](https://github.com/verygoodplugins/whatsapp-mcp/blob/main/ROADMAP.md) "in scope" list, **or** I've opened an issue first to discuss
  - Fits **Webhook reliability** (captionless media should reach the webhook, same as images).
- [x] PR is focused on one concern (split if not)
- [x] PR is ≤ ~300 LOC, **or** justified in the description

## Linked issues

None yet (clear bug fix; happy to open a tracking issue if preferred).

## Testing

- [x] Added or updated tests
- [ ] Ran `uv run pytest -v` (Python changes)
- [ ] Ran `golangci-lint run` and `go build ./...` (Go changes)
  - `go test` for new/related cases and `go build ./...` passed locally; `golangci-lint` was not installed on this machine.
- [x] Manually exercised the affected code path
  - Live WhatsApp PTT without caption now produces a webhook with `mediaType=audio`.

## Docs

- [ ] Updated `README.md` (if user-visible)
- [ ] Updated `AGENTS.md` / `CLAUDE.md` (if contributor-visible)
- [ ] Updated tool descriptions in `whatsapp-mcp-server/main.py` (if MCP tools changed)
- [ ] Updated `.env.example` (if env vars changed)

No user-facing MCP tool or env changes; webhook already supported `mediaType` for images.

## Risk / rollback

- Sync download blocks `handleMessage` for audio the same way images already do; large non-PTT audio may delay handling and enlarge webhook JSON (base64 via existing `SendWebhookWithMedia`).
- Revert this PR to restore prior “text or image only” webhook gate.

## AI disclosure

**This PR was AI-assisted / generated with Cursor** (human-directed bug fix and review). Please scrutinize accordingly.

Made with [Cursor](https://cursor.com)