### PR TITLE
fix(bridge): store and webhook contact/vCard shares

### DIFF
--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -882,6 +882,23 @@ func extractTextContent(msg *waProto.Message) string {
 		return doc.GetCaption()
 	}
 
+	// Contact shares have no conversation text; summarise name + TEL for storage/search.
+	if c := msg.GetContactMessage(); c != nil {
+		return formatContactMessage(c)
+	}
+	if arr := msg.GetContactsArrayMessage(); arr != nil {
+		parts := make([]string, 0, len(arr.GetContacts())+1)
+		if n := strings.TrimSpace(arr.GetDisplayName()); n != "" {
+			parts = append(parts, n)
+		}
+		for _, c := range arr.GetContacts() {
+			if s := formatContactMessage(c); s != "" {
+				parts = append(parts, s)
+			}
+		}
+		return strings.Join(parts, "\n")
+	}
+
 	// WhatsApp Business templates arrive hydrated — body lives in
 	// HydratedTemplate.HydratedContentText. Without this branch every
 	// template-sent message (e.g. WABA Connect Hrms_* notifications)
@@ -1492,7 +1509,50 @@ func extractMediaInfo(msg *waProto.Message, msgTimestamp time.Time, msgID string
 			stk.GetURL(), stk.GetMediaKey(), stk.GetFileSHA256(), stk.GetFileEncSHA256(), stk.GetFileLength()
 	}
 
+	// Contact shares have no downloadable media URL; set mediaType so empty-caption
+	// contacts are still stored and eligible for webhook forwarding.
+	if msg.GetContactMessage() != nil {
+		return "contact", "contact_" + suffix + ".vcf", "", nil, nil, nil, 0
+	}
+	if msg.GetContactsArrayMessage() != nil {
+		return "contact", "contacts_" + suffix + ".vcf", "", nil, nil, nil, 0
+	}
+
 	return "", "", "", nil, nil, nil, 0
+}
+
+// formatContactMessage summarises a contact share as display name plus TEL lines.
+func formatContactMessage(c *waProto.ContactMessage) string {
+	if c == nil {
+		return ""
+	}
+	name := strings.TrimSpace(c.GetDisplayName())
+	vcard := c.GetVcard()
+	var tels []string
+	for _, line := range strings.Split(vcard, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(strings.ToUpper(line), "TEL") {
+			continue
+		}
+		if i := strings.Index(line, ":"); i >= 0 {
+			if tel := strings.TrimSpace(line[i+1:]); tel != "" {
+				tels = append(tels, tel)
+			}
+		}
+	}
+	switch {
+	case name != "" && len(tels) > 0:
+		return fmt.Sprintf("Contact: %s (%s)", name, strings.Join(tels, ", "))
+	case name != "":
+		return "Contact: " + name
+	case len(tels) > 0:
+		return "Contact: (" + strings.Join(tels, ", ") + ")"
+	default:
+		if strings.TrimSpace(vcard) != "" {
+			return "Contact: (vCard)"
+		}
+		return ""
+	}
 }
 
 // resolveLIDChat resolves a LID-based chat JID to its phone-based equivalent
@@ -1733,18 +1793,24 @@ func handleMessage(client *whatsmeow.Client, messageStore *MessageStore, msg *ev
 
 	// Send webhook for incoming messages.
 	// Forward self-messages when FORWARD_SELF=true.
-	// Always forward image messages (even without a text caption) so the AI vision
-	// pipeline can analyse the image content.
+	// Always forward image and contact messages even without a text caption.
 	shouldForward := forwardSelfMessages || !msg.Info.IsFromMe
 	hasText := content != ""
 	hasImage := mediaType == "image"
+	hasContact := mediaType == "contact"
 
-	if shouldForward && (hasText || hasImage) {
+	if shouldForward && (hasText || hasImage || hasContact) {
 		if hasImage {
 			SendWebhookWithMedia(
 				sender, content, chatJID, msg.Info.IsFromMe,
 				quotedMessageId, quotedSender, quotedContent, quotedIsFromMe, mentionedJIDs,
 				msg.Info.ID, mediaType, imageMimeType, filename, imageDownloadPath,
+			)
+		} else if hasContact {
+			SendWebhookWithMedia(
+				sender, content, chatJID, msg.Info.IsFromMe,
+				quotedMessageId, quotedSender, quotedContent, quotedIsFromMe, mentionedJIDs,
+				msg.Info.ID, mediaType, "text/vcard", filename, "",
 			)
 		} else {
 			SendWebhook(sender, content, chatJID, msg.Info.IsFromMe, quotedMessageId, quotedSender, quotedContent, quotedIsFromMe, mentionedJIDs)

--- a/whatsapp-bridge/main_test.go
+++ b/whatsapp-bridge/main_test.go
@@ -1208,6 +1208,26 @@ func TestExtractTextContent_SurfacesMediaCaptions(t *testing.T) {
 			want: "",
 		},
 		{
+			name: "ContactMessage with name and TEL",
+			msg: &waProto.Message{
+				ContactMessage: &waProto.ContactMessage{
+					DisplayName: proto.String("Alex Keyter"),
+					Vcard:       proto.String("BEGIN:VCARD\nVERSION:3.0\nFN:Alex Keyter\nTEL;TYPE=CELL:+44 7958 023533\nEND:VCARD\n"),
+				},
+			},
+			want: "Contact: Alex Keyter (+44 7958 023533)",
+		},
+		{
+			name: "ContactMessage with name only",
+			msg: &waProto.Message{
+				ContactMessage: &waProto.ContactMessage{
+					DisplayName: proto.String("No Number"),
+					Vcard:       proto.String("BEGIN:VCARD\nFN:No Number\nEND:VCARD\n"),
+				},
+			},
+			want: "Contact: No Number",
+		},
+		{
 			name: "Nil message returns empty",
 			msg:  nil,
 			want: "",
@@ -1278,6 +1298,30 @@ func TestExtractMediaInfo_NoMediaReturnsEmpty(t *testing.T) {
 			gotType, gotFile, gotURL, len(gotKey), gotLen)
 	}
 }
+
+func TestExtractMediaInfo_Contact(t *testing.T) {
+	ts := time.Unix(1710000000, 0).UTC()
+	msgID := "TEST_CONTACT_ID"
+	msg := &waProto.Message{
+		ContactMessage: &waProto.ContactMessage{
+			DisplayName: proto.String("Alex Keyter"),
+			Vcard:       proto.String("BEGIN:VCARD\nTEL:+447958023533\nEND:VCARD\n"),
+		},
+	}
+	gotType, gotFile, gotURL, gotKey, _, _, gotLen := extractMediaInfo(msg, ts, msgID)
+	if gotType != "contact" {
+		t.Errorf("mediaType = %q, want contact", gotType)
+	}
+	wantFile := "contact_" + ts.Format("20060102_150405") + "_" + msgID + ".vcf"
+	if gotFile != wantFile {
+		t.Errorf("filename = %q, want %q", gotFile, wantFile)
+	}
+	if gotURL != "" || gotKey != nil || gotLen != 0 {
+		t.Errorf("contact should have empty download metadata: url=%q keyLen=%d len=%d",
+			gotURL, len(gotKey), gotLen)
+	}
+}
+
 
 func TestMigrateLegacyLIDChatsToPhoneJIDs_AggregatesByPhoneJIDDeterministically(t *testing.T) {
 	ms := newTestMessageStore(t)
@@ -1354,6 +1398,27 @@ func TestMigrateLegacyLIDChatsToPhoneJIDs_AggregatesByPhoneJIDDeterministically(
 // buildImageMessage constructs an events.Message that carries an ImageMessage
 // with no download metadata (URL/media-key are empty), so handleMessage will
 // classify it as an image but skip the synchronous download attempt.
+
+func buildContactMessage(chat, sender types.JID, isFromMe bool, name, vcard string) *events.Message {
+	return &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Chat:     chat,
+				Sender:   sender,
+				IsFromMe: isFromMe,
+			},
+			ID:        "test-contact-001",
+			Timestamp: time.Now(),
+		},
+		Message: &waProto.Message{
+			ContactMessage: &waProto.ContactMessage{
+				DisplayName: proto.String(name),
+				Vcard:       proto.String(vcard),
+			},
+		},
+	}
+}
+
 func buildImageMessage(chat, sender types.JID, isFromMe bool, caption string) *events.Message {
 	img := &waProto.ImageMessage{}
 	if caption != "" {
@@ -1484,6 +1549,42 @@ func TestHandleMessage_ImageWithCaption_WebhookForwarded(t *testing.T) {
 
 // queryCallResult returns the (result, duration_sec, reason) for a call row,
 // or empties if no row exists.
+
+// TestHandleMessage_Contact_WebhookForwarded verifies contact/vCard shares are
+// stored and webhooked with a text summary and mediaType=contact.
+func TestHandleMessage_Contact_WebhookForwarded(t *testing.T) {
+	srv, webhookCh := captureWebhook(t)
+	t.Setenv("WEBHOOK_URL", srv.URL)
+
+	client := newTestClient(&mockLIDStore{})
+	ms := newTestMessageStore(t)
+	logger := testLogger()
+
+	vcard := "BEGIN:VCARD\nVERSION:3.0\nFN:Alex Keyter\nTEL;TYPE=CELL:+44 7958 023533\nEND:VCARD\n"
+	msg := buildContactMessage(phonePN, phonePN, false, "Alex Keyter", vcard)
+	handleMessage(client, ms, msg, logger)
+
+	if count := queryMessageCount(ms, phonePN.String()); count != 1 {
+		t.Errorf("expected 1 message stored, got %d", count)
+	}
+
+	select {
+	case payload := <-webhookCh:
+		if payload.MediaType != "contact" {
+			t.Errorf("expected mediaType=contact, got %q", payload.MediaType)
+		}
+		if payload.MessageID != "test-contact-001" {
+			t.Errorf("expected messageId=test-contact-001, got %q", payload.MessageID)
+		}
+		want := "Contact: Alex Keyter (+44 7958 023533)"
+		if payload.Content != want {
+			t.Errorf("expected content %q, got %q", want, payload.Content)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for webhook call")
+	}
+}
+
 func queryCallResult(ms *MessageStore, callID, chatJID string) (result string, duration sql.NullInt64, reason sql.NullString, found bool) {
 	err := ms.db.QueryRow(
 		"SELECT result, duration_sec, reason FROM calls WHERE call_id = ? AND chat_jid = ?",


### PR DESCRIPTION
## Summary

- Contact/vCard shares arrived with empty conversation text and no `mediaType`, so `handleMessage` returned early (nothing stored, no webhook).
- Summarise display name + TEL lines from the vCard, set `mediaType=contact`, and forward via `SendWebhookWithMedia`.

## Type of change

- [x] `fix` — bug fix
- [ ] `feat` — new feature
- [ ] `chore` / `docs` / `ci` / `refactor` / `test` / `perf`
- [ ] Breaking change (`!` in commit, or `BREAKING CHANGE:` in body)

## Scope check

- [x] This change fits the [`ROADMAP.md`](https://github.com/verygoodplugins/whatsapp-mcp/blob/main/ROADMAP.md) "in scope" list, **or** I've opened an issue first to discuss
  - Fits **Webhook reliability** / contact resolution-adjacent inbound handling.
  - Note: populates the existing webhook `mediaType` field with a new value (`contact`); content is a short text summary. Happy to discuss payload shape in an issue if maintainers prefer an opt-in flag.
- [x] PR is focused on one concern (split if not)
- [x] PR is ≤ ~300 LOC, **or** justified in the description (~170 LOC)

## Linked issues

None yet (clear bug fix; happy to open a tracking issue if preferred).

## Testing

- [x] Added or updated tests
- [ ] Ran `uv run pytest -v` (Python changes)
- [ ] Ran `golangci-lint run` and `go build ./...` (Go changes)
  - `go test` for new/related cases and `go build` passed locally; `golangci-lint` was not installed on this machine.
- [x] Manually exercised the affected code path
  - Live WhatsApp contact share now stores a summary and webhooks with `mediaType=contact`.

## Docs

- [ ] Updated `README.md` (if user-visible)
- [ ] Updated `AGENTS.md` / `CLAUDE.md` (if contributor-visible)
- [ ] Updated tool descriptions in `whatsapp-mcp-server/main.py` (if MCP tools changed)
- [ ] Updated `.env.example` (if env vars changed)

No MCP tool or env changes. Downstream consumers that only look at `content` still get a `Contact: Name (TEL…)` summary.

## Risk / rollback

- Rows use `mediaType=contact` with empty download URL/keys (no file to download). `download_media` on those rows will fail — same class of “typed but undownloadable” metadata as some other non-file message types.
- TEL parsing looks for lines prefixed `TEL` (covers common WhatsApp vCards; prefixed forms like `ITEM1.TEL:` are not handled).
- Revert this PR to restore prior skip-on-empty behaviour for contacts.

## AI disclosure

**This PR was AI-assisted / generated with Cursor** (human-directed bug fix and review). Please scrutinize accordingly.

Made with [Cursor](https://cursor.com)