### PR TITLE
fix: exit orphaned stdio MCP servers on parent death

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,3 +65,8 @@ WHATSAPP_API_URL=http://localhost:8080/api
 # 0.0.0.0 to expose it on the network and put authentication in front of it.
 # WHATSAPP_MCP_HOST=127.0.0.1
 # WHATSAPP_MCP_PORT=8000
+
+# Stdio parent-liveness watchdog poll interval (seconds).
+# Soft stdin EOF alone does not exit; process exits when the original parent is
+# gone (POSIX reparent) or on SIGTERM/SIGINT/SIGHUP.
+# WHATSAPP_PARENT_WATCHDOG_S=30

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,7 @@ A failing blocking job is a hard block — fix it or explain in the PR why it's 
 | `WHATSAPP_MCP_PORT` | `8000` | Port for the `http`/`sse` transports |
 | `WEBHOOK_URL` | `http://localhost:8769/whatsapp/webhook` | Outgoing webhook for incoming messages (empty = disabled) |
 | `FORWARD_SELF` | `true` | Whether self-sent messages are forwarded (`getEnvBool` default; set `FORWARD_SELF=false` to disable) |
+| `WHATSAPP_PARENT_WATCHDOG_S` | `30` | Stdio parent-liveness poll interval (seconds). Exits when the original parent is gone (POSIX reparent). Soft stdin EOF alone does not exit. |
 
 When adding a new env var: document it here, in `README.md`, and in `.env.example`.
 

--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ Copy `.env.example` to `.env` and configure as needed:
 | `WHATSAPP_MCP_TRANSPORT` | `stdio`                                | MCP transport to serve clients: `stdio`, `http`, or `sse` |
 | `WHATSAPP_MCP_HOST`    | `127.0.0.1`                              | Bind address for the `http`/`sse` transports |
 | `WHATSAPP_MCP_PORT`    | `8000`                                   | Port for the `http`/`sse` transports |
+| `WHATSAPP_PARENT_WATCHDOG_S` | `30`                              | Stdio parent-liveness poll interval (seconds); exits on parent reparent only |
 
 ### MCP transport (stdio vs http/sse)
 

--- a/whatsapp-mcp-server/main.py
+++ b/whatsapp-mcp-server/main.py
@@ -421,6 +421,8 @@ def shutdown_handler(signum, frame):
 
 
 if __name__ == "__main__":
+    # Capture before any await — os.getppid() is dynamic.
+    parent_pid = os.getppid()
     # Register signal handlers for clean shutdown
     signal.signal(signal.SIGINT, shutdown_handler)
     signal.signal(signal.SIGTERM, shutdown_handler)
@@ -442,5 +444,5 @@ if __name__ == "__main__":
         raise SystemExit(str(exc)) from None
 
     if transport == 'stdio':
-        install_stdio_parent_watchdog('WHATSAPP_PARENT_WATCHDOG_S')
+        install_stdio_parent_watchdog('WHATSAPP_PARENT_WATCHDOG_S', parent_pid=parent_pid)
     mcp.run(transport=transport)

--- a/whatsapp-mcp-server/main.py
+++ b/whatsapp-mcp-server/main.py
@@ -1,5 +1,6 @@
 import os
 import signal
+from parent_watchdog import install_stdio_parent_watchdog
 import sys
 from typing import Any
 
@@ -440,4 +441,6 @@ if __name__ == "__main__":
     except ValueError as exc:
         raise SystemExit(str(exc)) from None
 
+    if transport == 'stdio':
+        install_stdio_parent_watchdog('WHATSAPP_PARENT_WATCHDOG_S')
     mcp.run(transport=transport)

--- a/whatsapp-mcp-server/main.py
+++ b/whatsapp-mcp-server/main.py
@@ -443,6 +443,6 @@ if __name__ == "__main__":
     except ValueError as exc:
         raise SystemExit(str(exc)) from None
 
-    if transport == 'stdio':
-        install_stdio_parent_watchdog('WHATSAPP_PARENT_WATCHDOG_S', parent_pid=parent_pid)
+    if transport == "stdio":
+        install_stdio_parent_watchdog("WHATSAPP_PARENT_WATCHDOG_S", parent_pid=parent_pid)
     mcp.run(transport=transport)

--- a/whatsapp-mcp-server/main.py
+++ b/whatsapp-mcp-server/main.py
@@ -1,12 +1,12 @@
 import os
 import signal
-from parent_watchdog import install_stdio_parent_watchdog
 import sys
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
 
 from mcp_config import resolve_host, resolve_port, resolve_transport
+from parent_watchdog import install_stdio_parent_watchdog
 from whatsapp import (
     download_media as whatsapp_download_media,
 )

--- a/whatsapp-mcp-server/parent_watchdog.py
+++ b/whatsapp-mcp-server/parent_watchdog.py
@@ -16,8 +16,7 @@ from __future__ import annotations
 import os
 import threading
 import time
-from typing import Callable
-
+from collections.abc import Callable
 
 DEFAULT_PARENT_WATCHDOG_S = 30.0
 MIN_PARENT_WATCHDOG_S = 0.1

--- a/whatsapp-mcp-server/parent_watchdog.py
+++ b/whatsapp-mcp-server/parent_watchdog.py
@@ -1,0 +1,63 @@
+"""Parent-liveness watchdog for stdio MCP servers.
+
+When an intermediate wrapper keeps stdin open after the client dies, the
+Python MCP stdio loop never sees EOF and the process leaks forever (swap
+thrash). This watchdog exits once os.getppid() changes from the original
+parent (POSIX reparenting).
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from typing import Callable
+
+
+DEFAULT_PARENT_WATCHDOG_S = 30.0
+MIN_PARENT_WATCHDOG_S = 0.1
+
+
+def parse_watchdog_interval_s(raw: str | None) -> float:
+    if raw is None or raw.strip() == "":
+        return DEFAULT_PARENT_WATCHDOG_S
+    try:
+        value = float(raw)
+    except ValueError:
+        return DEFAULT_PARENT_WATCHDOG_S
+    if value <= 0:
+        return DEFAULT_PARENT_WATCHDOG_S
+    return max(value, MIN_PARENT_WATCHDOG_S)
+
+
+def start_parent_watchdog(
+    parent_pid: int,
+    interval_s: float,
+    on_dead: Callable[[], None],
+    *,
+    is_parent_gone: Callable[[int], bool] | None = None,
+) -> threading.Thread:
+    probe = is_parent_gone or (lambda pid: os.getppid() != pid)
+    fired = {"value": False}
+
+    def _loop() -> None:
+        while not fired["value"]:
+            if probe(parent_pid):
+                fired["value"] = True
+                on_dead()
+                return
+            time.sleep(interval_s)
+
+    thread = threading.Thread(target=_loop, name="mcp-parent-watchdog", daemon=True)
+    thread.start()
+    return thread
+
+
+def install_stdio_parent_watchdog(env_name: str) -> None:
+    parent_pid = os.getppid()
+    interval = parse_watchdog_interval_s(os.environ.get(env_name))
+
+    def _exit() -> None:
+        os._exit(0)
+
+    start_parent_watchdog(parent_pid, interval, _exit)

--- a/whatsapp-mcp-server/parent_watchdog.py
+++ b/whatsapp-mcp-server/parent_watchdog.py
@@ -4,6 +4,11 @@ When an intermediate wrapper keeps stdin open after the client dies, the
 Python MCP stdio loop never sees EOF and the process leaks forever (swap
 thrash). This watchdog exits once os.getppid() changes from the original
 parent (POSIX reparenting).
+
+Soft stdin EOF is intentional: do NOT hard-exit on EOF alone. One-shot
+pipe clients must be able to finish in-flight handlers. Hard exit is
+reserved for parent-watchdog reparent (and OS signals installed by the
+host process).
 """
 
 from __future__ import annotations
@@ -53,11 +58,16 @@ def start_parent_watchdog(
     return thread
 
 
-def install_stdio_parent_watchdog(env_name: str) -> None:
-    parent_pid = os.getppid()
+def install_stdio_parent_watchdog(
+    env_name: str,
+    *,
+    parent_pid: int | None = None,
+) -> None:
+    # Prefer a pid captured before any await in main — getppid() is dynamic.
+    pinned = os.getppid() if parent_pid is None else parent_pid
     interval = parse_watchdog_interval_s(os.environ.get(env_name))
 
     def _exit() -> None:
         os._exit(0)
 
-    start_parent_watchdog(parent_pid, interval, _exit)
+    start_parent_watchdog(pinned, interval, _exit)

--- a/whatsapp-mcp-server/pyproject.toml
+++ b/whatsapp-mcp-server/pyproject.toml
@@ -35,7 +35,7 @@ Repository = "https://github.com/verygoodplugins/whatsapp-mcp"
 Issues = "https://github.com/verygoodplugins/whatsapp-mcp/issues"
 
 [tool.setuptools]
-py-modules = ["main", "whatsapp", "audio", "mcp_config"]
+py-modules = ["main", "whatsapp", "audio", "mcp_config", "parent_watchdog"]
 
 [tool.mcp]
 name = "io.github.verygoodplugins/whatsapp-mcp"

--- a/whatsapp-mcp-server/tests/test_parent_watchdog.py
+++ b/whatsapp-mcp-server/tests/test_parent_watchdog.py
@@ -1,0 +1,26 @@
+import time
+
+from parent_watchdog import (
+    DEFAULT_PARENT_WATCHDOG_S,
+    parse_watchdog_interval_s,
+    start_parent_watchdog,
+)
+
+
+def test_parse_defaults():
+    assert parse_watchdog_interval_s(None) == DEFAULT_PARENT_WATCHDOG_S
+    assert parse_watchdog_interval_s("") == DEFAULT_PARENT_WATCHDOG_S
+    assert parse_watchdog_interval_s("nope") == DEFAULT_PARENT_WATCHDOG_S
+    assert parse_watchdog_interval_s("0") == DEFAULT_PARENT_WATCHDOG_S
+
+
+def test_parse_positive_floor():
+    assert parse_watchdog_interval_s("2.5") == 2.5
+    assert parse_watchdog_interval_s("0.01") == 0.1
+
+
+def test_watchdog_fires_once():
+    hits = []
+    start_parent_watchdog(1, 0.05, lambda: hits.append(1), is_parent_gone=lambda _pid: True)
+    time.sleep(0.2)
+    assert hits == [1]


### PR DESCRIPTION
## Summary
Stdio MCP servers can leak forever when a client (Claude Desktop / Cursor / Grok / Codex) abandons a session but an intermediate wrapper keeps the stdin write-end open. No EOF arrives, the process stays alive, and repeated leaks cause multi-GB swap thrashing.

This adds a parent-liveness watchdog (same approach as mcp-automem): when `ppid` / `os.getppid()` changes from the startup parent (POSIX reparent), exit promptly.

## Test plan
- [x] Unit tests for watchdog interval parsing + one-shot fire
- [ ] Manual: spawn via wrapper that holds stdin open, kill wrapper, confirm leaf exits within watchdog interval