### PR TITLE
feat: add a configurable Bridge port

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,7 +462,21 @@ message DBs, media, and `.bridge-token`. Logs are left in
 
 | Flag                  | Default | Description                                                                                                                                                                                                                                                       |
 | --------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--port`              | `WHATSAPP_BRIDGE_PORT` or `8080` | REST API port. The command-line value takes precedence over the environment variable. Valid range: `1-65535`. |
 | `--full-history-pair` | `false` | Request full history at pair time. Only takes effect on a fresh pair (no existing `whatsapp.db`); no-op for already-paired sessions. The phone ultimately decides the actual history window sent — see [Requesting full history](#requesting-full-history) below. |
+
+For a one-off launch on another port:
+
+```bash
+cd whatsapp-bridge
+go run . --port 9090
+```
+
+Point the MCP server at the same port:
+
+```bash
+WHATSAPP_API_URL=http://localhost:9090/api uv run main.py
+```
 
 ### Requesting full history
 

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -47,6 +47,11 @@ var forwardSelfMessages = getEnvBool("FORWARD_SELF", true)
 var fullHistoryPairFlag = flag.Bool("full-history-pair", false,
 	"Request full history at pair time (only effective when re-pairing; no-op for existing sessions)")
 
+// An empty value preserves WHATSAPP_BRIDGE_PORT (or the default 8080).
+// A CLI value takes precedence so one-off launches do not need env changes.
+var bridgePortFlag = flag.String("port", "",
+	"REST API port (1-65535; overrides WHATSAPP_BRIDGE_PORT)")
+
 const whatsmeowDBPath = "store/whatsapp.db"
 
 // getEnvBool reads a boolean env var with a default.
@@ -64,6 +69,27 @@ func getEnvBool(key string, def bool) bool {
 	default:
 		return def
 	}
+}
+
+func resolveBridgePort(cliValue, envValue string) (int, error) {
+	value := ""
+	source := ""
+	if cliValue != "" {
+		value = strings.TrimSpace(cliValue)
+		source = "--port"
+	} else if envValue != "" {
+		value = strings.TrimSpace(envValue)
+		source = "WHATSAPP_BRIDGE_PORT"
+	}
+	if source == "" {
+		return 8080, nil
+	}
+
+	port, err := strconv.Atoi(value)
+	if err != nil || port < 1 || port > 65535 {
+		return 0, fmt.Errorf("%s=%q, must be 1-65535", source, value)
+	}
+	return port, nil
 }
 
 // Message represents a chat message for our client
@@ -2402,14 +2428,10 @@ func main() {
 	// WhatsApp connection, so it's safe to do this early alongside the token
 	// load below — and failing fast here means we don't run a QR-pairing
 	// flow only to error out on an invalid port afterwards.
-	port := 8080
-	if p := os.Getenv("WHATSAPP_BRIDGE_PORT"); p != "" {
-		v, err := strconv.Atoi(p)
-		if err != nil || v < 1 || v > 65535 {
-			logger.Errorf("Invalid WHATSAPP_BRIDGE_PORT=%q, must be 1-65535", p)
-			return
-		}
-		port = v
+	port, err := resolveBridgePort(*bridgePortFlag, os.Getenv("WHATSAPP_BRIDGE_PORT"))
+	if err != nil {
+		logger.Errorf("Invalid bridge port: %v", err)
+		return
 	}
 
 	// Load (or generate on first run) the bearer token used to authenticate

--- a/whatsapp-bridge/main_test.go
+++ b/whatsapp-bridge/main_test.go
@@ -68,6 +68,52 @@ func newTestClientWithSelf(lidStore store.LIDStore, selfPhone types.JID) *whatsm
 	return c
 }
 
+func TestResolveBridgePort(t *testing.T) {
+	tests := []struct {
+		name    string
+		cli     string
+		env     string
+		want    int
+		wantErr bool
+	}{
+		{name: "default", want: 8080},
+		{name: "environment", env: "9090", want: 9090},
+		{name: "trim environment", env: " 9091 ", want: 9091},
+		{name: "CLI", cli: "7070", want: 7070},
+		{name: "CLI overrides environment", cli: "7071", env: "9090", want: 7071},
+		{name: "valid CLI overrides invalid environment", cli: "7072", env: "invalid", want: 7072},
+		{name: "invalid CLI does not fall back", cli: "invalid", env: "9090", wantErr: true},
+		{name: "empty CLI value", cli: " ", env: "9090", wantErr: true},
+		{name: "zero", cli: "0", wantErr: true},
+		{name: "too high", env: "65536", wantErr: true},
+		{name: "negative", env: "-1", wantErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := resolveBridgePort(test.cli, test.env)
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("resolveBridgePort(%q, %q) = %d, want error", test.cli, test.env, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveBridgePort(%q, %q) error: %v", test.cli, test.env, err)
+			}
+			if got != test.want {
+				t.Fatalf(
+					"resolveBridgePort(%q, %q) = %d, want %d",
+					test.cli,
+					test.env,
+					got,
+					test.want,
+				)
+			}
+		})
+	}
+}
+
 // querySender returns the sender column for the first message stored under a
 // chat JID, or empty string if none.
 func querySender(ms *MessageStore, chatJID string) string {


### PR DESCRIPTION
## Summary

Allows the WhatsApp Bridge to run on a port other than `8080`. The same listener also serves the local administration panel introduced by #179.

Closes #178

## What changed

- Added the `--port` command-line option.
- Kept `WHATSAPP_BRIDGE_PORT` as the environment-based configuration.
- Made the command-line value take precedence over the environment variable.
- Kept `8080` as the default when neither option is provided.
- Added validation for the valid TCP port range, `1-65535`.
- Added tests for defaults, environment configuration, command-line overrides, whitespace handling, and invalid values.
- Documented how to point `WHATSAPP_API_URL` at the selected Bridge port.

## Examples

```bash
cd whatsapp-bridge
go run . --port 9090
```

The MCP server can use the same Bridge instance with:

```bash
WHATSAPP_API_URL=http://localhost:9090/api uv run main.py
```

When combined with #179, the administration panel is available at:

```text
http://127.0.0.1:9090/admin/
```

## Validation

- `go test -race ./...`
- `go vet ./...`
- Go production build
- documentation review
