### PR TITLE
feat: optional caption on send_file

### DIFF
--- a/whatsapp-mcp-server/main.py
+++ b/whatsapp-mcp-server/main.py
@@ -406,20 +406,26 @@ def mark_messages_read(
 
 
 @mcp.tool()
-def send_file(recipient: str, media_path: str) -> dict[str, Any]:
-    """Send a file such as a picture, raw audio, video or document via WhatsApp to the specified recipient. For group messages use the JID.
+def send_file(recipient: str, media_path: str, caption: str = "") -> dict[str, Any]:
+    """Send a file (image, video, document) via WhatsApp, optionally with a caption.
+
+    When `caption` is provided, the file and text arrive as a single
+    attachment-with-caption message (one bubble in the WA UI), instead of
+    needing a separate follow-up send_message call. For group chats use the JID.
 
     Args:
-        recipient: The recipient - either a phone number with country code but no + or other symbols,
-                 or a JID (e.g., "123456789@s.whatsapp.net" or a group JID like "123456789@g.us")
-        media_path: The absolute path to the media file to send (image, video, document)
+        recipient: Either a phone number with country code (no + or symbols),
+                 or a JID (e.g., "123456789@s.whatsapp.net" or "123456789@g.us")
+        media_path: Absolute path to the media file (image, video, document)
+        caption: Optional text rendered with the file as a caption. Omit for a
+                 bare attachment.
 
     Returns:
         A dictionary containing success status and a status message
     """
 
     # Call the whatsapp_send_file function
-    success, status_message = whatsapp_send_file(recipient, media_path)
+    success, status_message = whatsapp_send_file(recipient, media_path, caption)
     return {"success": success, "message": status_message}
 
 

--- a/whatsapp-mcp-server/tests/test_send_file_caption.py
+++ b/whatsapp-mcp-server/tests/test_send_file_caption.py
@@ -1,0 +1,75 @@
+import whatsapp
+
+
+class DummyResponse:
+    def __init__(self, status_code=200, payload=None, text="OK"):
+        self.status_code = status_code
+        self._payload = payload or {"success": True, "message": "sent"}
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+def _capture_post(monkeypatch, calls):
+    def fake_post(url, json, headers=None):
+        calls.append({"url": url, "json": json, "headers": headers})
+        return DummyResponse()
+
+    monkeypatch.setattr(whatsapp.requests, "post", fake_post)
+
+
+def test_send_file_with_caption_sends_one_request(monkeypatch, tmp_path):
+    """The caption rides along in the same /send call, so the file and text
+    arrive as a single attachment-with-caption message rather than two."""
+    calls = []
+    media = tmp_path / "report.pdf"
+    media.write_bytes(b"%PDF-1.4")
+    monkeypatch.setenv("WHATSAPP_BRIDGE_TOKEN", "test-token")
+    _capture_post(monkeypatch, calls)
+
+    success, _ = whatsapp.send_file("12025551234@s.whatsapp.net", str(media), "Q3 numbers")
+
+    assert success is True
+    assert len(calls) == 1
+    assert calls[0]["url"].endswith("/send")
+    assert calls[0]["headers"] == {"Authorization": "Bearer test-token"}
+    payload = calls[0]["json"]
+    assert payload["media_path"] == str(media)
+    assert payload["message"] == "Q3 numbers"
+
+
+def test_send_file_without_caption_omits_message_field(monkeypatch, tmp_path):
+    """A bare attachment must not send an empty message field — the bridge would
+    otherwise set an empty Caption on the media message."""
+    calls = []
+    media = tmp_path / "photo.jpg"
+    media.write_bytes(b"\xff\xd8\xff")
+    _capture_post(monkeypatch, calls)
+
+    success, _ = whatsapp.send_file("12025551234@s.whatsapp.net", str(media))
+
+    assert success is True
+    assert "message" not in calls[0]["json"]
+
+
+def test_send_file_empty_caption_omits_message_field(monkeypatch, tmp_path):
+    calls = []
+    media = tmp_path / "photo.jpg"
+    media.write_bytes(b"\xff\xd8\xff")
+    _capture_post(monkeypatch, calls)
+
+    whatsapp.send_file("12025551234@s.whatsapp.net", str(media), "")
+
+    assert "message" not in calls[0]["json"]
+
+
+def test_send_file_missing_file_does_not_call_bridge(monkeypatch, tmp_path):
+    calls = []
+    monkeypatch.setattr(whatsapp.requests, "post", lambda *a, **kw: calls.append(1))
+
+    success, message = whatsapp.send_file("12025551234@s.whatsapp.net", str(tmp_path / "absent.pdf"), "hi")
+
+    assert success is False
+    assert "not found" in message
+    assert calls == []

--- a/whatsapp-mcp-server/whatsapp.py
+++ b/whatsapp-mcp-server/whatsapp.py
@@ -1080,7 +1080,13 @@ def send_message(
         return False, f"Unexpected error: {str(e)}"
 
 
-def send_file(recipient: str, media_path: str) -> tuple[bool, str]:
+def send_file(recipient: str, media_path: str, caption: str = "") -> tuple[bool, str]:
+    """Send a media file (image, video, document) with an optional caption.
+
+    The bridge populates the WA media-message Caption field from `message`, so
+    passing both in one /api/send call produces a single attachment-with-caption
+    message instead of two separate messages.
+    """
     try:
         # Validate input
         if not recipient:
@@ -1094,6 +1100,8 @@ def send_file(recipient: str, media_path: str) -> tuple[bool, str]:
 
         url = f"{WHATSAPP_API_BASE_URL}/send"
         payload = {"recipient": recipient, "media_path": media_path}
+        if caption:
+            payload["message"] = caption
 
         response = requests.post(url, json=payload, headers=_bridge_headers())
 


### PR DESCRIPTION
## Summary

- `send_file` gains an optional `caption`, so a file and its text arrive as one attachment-with-caption message instead of an attachment followed by a separate `send_message` bubble.
- The README already documents `caption (optional)` under `send_file` — the parameter was documented but never implemented. This closes that gap rather than adding a new concept.
- The bridge already fills the WA media-message `Caption` field from the request's `message`, so this is plumbing: the client forwards the caption, and omits the field entirely when it is empty.
- Resubmitted from #166 as one concern, against current `main`, with tests — per your close comment there.

## Type of change

- [ ] `fix` — bug fix
- [x] `feat` — new feature
- [ ] `chore` / `docs` / `ci` / `refactor` / `test` / `perf`
- [ ] Breaking change

## Scope check

- [x] Fits ROADMAP "in scope" — *Media handling: … MIME types, captions*
- [x] PR is focused on one concern
- [x] ~96 LOC, of which 75 are tests

## Linked issues

Refs #166 (closed; this is the caption half, split out as requested)

## Testing

- [x] Added or updated tests
- [x] Ran `uv run pytest -v` — full suite green
- [ ] Ran `golangci-lint run` / `go build ./...` — no Go changes in this PR
- [x] Manually exercised the affected code path

`test_send_file_caption.py`: a caption goes out as `message` in a single `/send` call carrying the auth header; the absent and empty-string cases both assert the key is *not* in the payload; a missing file still returns early without touching the bridge.

Manual: sent a captioned document to a self-chat against a live paired bridge and confirmed it renders as one bubble.

## Docs

- [x] `README.md` already describes this parameter — no change needed
- [ ] Updated `AGENTS.md` / `CLAUDE.md` — no contributor-visible change
- [x] Updated tool descriptions in `whatsapp-mcp-server/main.py`
- [ ] Updated `.env.example` — no new env vars

## Risk / rollback

Backwards compatible: `caption` defaults to `""` and the payload is byte-for-byte unchanged when it is empty, so no existing caller's behaviour moves. Revert is a clean revert of the single commit.

One thing I did **not** touch, since it is a separate concern: the README documents `send_file`'s path parameter as `file_path` while the tool takes `media_path` (same for `send_audio_message`). Happy to send that as its own docs PR if useful.