### PR TITLE
feat: add explicit message read receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A Model Context Protocol (MCP) server for WhatsApp, enabling Claude to read and 
 - **Message Management**: Search and read personal WhatsApp messages (text, images, videos, documents, audio)
 - **Contact Search**: Search contacts by name or phone number with `sender_display` format ("Name (phone)")
 - **Send Messages**: Send text messages to individuals or groups
+- **Read Receipts**: Explicitly mark selected messages as read across linked devices
 - **Media Support**: Send and download images, videos, documents, and voice messages
 - **Call History**: Capture incoming voice/video calls into a local SQLite table (live, 1:1 and group)
 - **Webhook Integration**: Forward incoming messages to external services
@@ -199,6 +200,24 @@ Inbound quoted replies are stored automatically. The `quoted_message_id` field i
 - "Send 'Hello!' to +1234567890"
 - "Message the team group saying 'Meeting at 3pm'"
 - "Reply to that message saying 'Sounds good'"
+
+#### `mark_messages_read`
+
+Mark one or more messages from the same chat and sender as read. This explicitly
+sends WhatsApp read receipts; reading or searching messages never does so
+automatically.
+
+**Parameters:**
+
+- `message_ids` (required): IDs of messages from the same chat and sender
+- `chat_jid` (required): JID of the chat containing the messages
+- `sender_jid` (required for groups): Full JID or bare phone number of the original message sender
+- `timestamp` (optional): RFC 3339 read timestamp; defaults to the current time
+
+**Natural Language Examples:**
+
+- "Mark those messages as read"
+- "Mark the last three messages from Alice in the team group as read"
 
 #### `send_reaction`
 
@@ -609,6 +628,7 @@ flowchart LR
     subgraph GoAPI["Go Bridge REST API"]
         direction TB
         SEND["/api/send"]
+        READ["/api/mark-read"]
         DOWN["/api/download"]
         REACT["/api/react"]
         TYPE["/api/typing"]
@@ -616,7 +636,7 @@ flowchart LR
         HEALTH["/api/health"]
     end
 
-    subgraph MCPTools["MCP Tools (14 total)"]
+    subgraph MCPTools["MCP Tools (15 total)"]
         direction TB
         CONT["Contact Tools<br/>search_contacts, get_contact"]
         MSG["Message Tools<br/>list_messages, send_message, etc."]

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -955,6 +955,14 @@ type SendMessageRequest struct {
 	Mentions []string `json:"mentions,omitempty"`
 }
 
+// MarkReadRequest is the request body for the /api/mark-read endpoint.
+type MarkReadRequest struct {
+	MessageIDs []string `json:"message_ids"`
+	ChatJID    string   `json:"chat_jid"`
+	SenderJID  string   `json:"sender_jid,omitempty"`
+	Timestamp  string   `json:"timestamp,omitempty"`
+}
+
 // ReactRequest is the request body for the /api/react endpoint.
 type ReactRequest struct {
 	Recipient string  `json:"recipient"`  // chat JID
@@ -2205,6 +2213,80 @@ func newRESTMux(client *whatsmeow.Client, messageStore *MessageStore, port int, 
 			Success: success,
 			Message: message,
 		})
+	}))
+
+	// Handler for explicitly sending read receipts for selected messages.
+	mux.HandleFunc("/api/mark-read", auth(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var req MarkReadRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "Invalid request format", http.StatusBadRequest)
+			return
+		}
+		if req.ChatJID == "" || len(req.MessageIDs) == 0 {
+			http.Error(w, "chat_jid and message_ids are required", http.StatusBadRequest)
+			return
+		}
+
+		messageIDs := make([]types.MessageID, len(req.MessageIDs))
+		for i, id := range req.MessageIDs {
+			if strings.TrimSpace(id) == "" {
+				http.Error(w, "message_ids must not contain empty values", http.StatusBadRequest)
+				return
+			}
+			messageIDs[i] = types.MessageID(id)
+		}
+
+		chatJID, err := types.ParseJID(req.ChatJID)
+		if err != nil || chatJID.User == "" || chatJID.Server == "" {
+			http.Error(w, "Invalid chat_jid", http.StatusBadRequest)
+			return
+		}
+
+		senderJID := types.EmptyJID
+		if req.SenderJID != "" {
+			if strings.Contains(req.SenderJID, "@") {
+				senderJID, err = types.ParseJID(req.SenderJID)
+			} else {
+				senderJID = types.NewJID(strings.TrimSpace(req.SenderJID), types.DefaultUserServer)
+			}
+			if err != nil || senderJID.User == "" || senderJID.Server == "" {
+				http.Error(w, "Invalid sender_jid", http.StatusBadRequest)
+				return
+			}
+		} else if chatJID.Server == types.GroupServer {
+			http.Error(w, "sender_jid is required for group read receipts", http.StatusBadRequest)
+			return
+		}
+
+		readAt := time.Now()
+		if req.Timestamp != "" {
+			readAt, err = time.Parse(time.RFC3339, req.Timestamp)
+			if err != nil {
+				http.Error(w, "timestamp must be RFC 3339", http.StatusBadRequest)
+				return
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if !client.IsConnected() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_ = json.NewEncoder(w).Encode(SendMessageResponse{
+				Success: false,
+				Message: "WhatsApp client is not connected. Please wait for reconnection.",
+			})
+			return
+		}
+		if err := client.MarkRead(context.Background(), messageIDs, readAt, chatJID, senderJID); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			_ = json.NewEncoder(w).Encode(SendMessageResponse{Success: false, Message: err.Error()})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(SendMessageResponse{Success: true, Message: "Messages marked as read"})
 	}))
 
 	// Handler for sending (or removing) emoji reactions

--- a/whatsapp-bridge/main_test.go
+++ b/whatsapp-bridge/main_test.go
@@ -2205,6 +2205,73 @@ func TestReactHandler_NoAuth_Returns401(t *testing.T) {
 	}
 }
 
+func TestMarkReadHandler_InvalidRequests_Return400(t *testing.T) {
+	const token = "supersecrettoken1234567890abcdef"
+	handler := newRESTMux(newTestClient(&mockLIDStore{}), newTestMessageStore(t), 8080, token, nil)
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"empty body", `{}`},
+		{"missing message_ids", `{"chat_jid":"15551234567@s.whatsapp.net"}`},
+		{"missing chat_jid", `{"message_ids":["3AABCDEF01234567"]}`},
+		{"empty message_id", `{"message_ids":["3AABCDEF01234567",""],"chat_jid":"15551234567@s.whatsapp.net"}`},
+		{"invalid chat_jid", `{"message_ids":["3AABCDEF01234567"],"chat_jid":"@s.whatsapp.net"}`},
+		{"invalid sender_jid", `{"message_ids":["3AABCDEF01234567"],"chat_jid":"15551234567@s.whatsapp.net","sender_jid":"@s.whatsapp.net"}`},
+		{"group missing sender_jid", `{"message_ids":["3AABCDEF01234567"],"chat_jid":"120363012345678901@g.us"}`},
+		{"invalid timestamp", `{"message_ids":["3AABCDEF01234567"],"chat_jid":"15551234567@s.whatsapp.net","timestamp":"yesterday"}`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:8080/api/mark-read", strings.NewReader(tc.body))
+			req.Header.Set("Authorization", "Bearer "+token)
+			req.Header.Set("Content-Type", "application/json")
+			resp := httptest.NewRecorder()
+
+			handler.ServeHTTP(resp, req)
+
+			if resp.Code != http.StatusBadRequest {
+				t.Errorf("body=%q: expected 400, got %d", tc.body, resp.Code)
+			}
+		})
+	}
+}
+
+func TestMarkReadHandler_Disconnected_Returns503(t *testing.T) {
+	const token = "supersecrettoken1234567890abcdef"
+	handler := newRESTMux(newTestClient(&mockLIDStore{}), newTestMessageStore(t), 8080, token, nil)
+
+	body := `{"message_ids":["3AABCDEF01234567"],"chat_jid":"120363012345678901@g.us","sender_jid":"15551234567","timestamp":"2026-08-11T18:30:00Z"}`
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:8080/api/mark-read", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	handler.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 for disconnected client, got %d", resp.Code)
+	}
+}
+
+func TestMarkReadHandler_NoAuth_Returns401(t *testing.T) {
+	const token = "supersecrettoken1234567890abcdef"
+	handler := newRESTMux(newTestClient(&mockLIDStore{}), newTestMessageStore(t), 8080, token, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:8080/api/mark-read",
+		strings.NewReader(`{"message_ids":["3AABCDEF01234567"],"chat_jid":"15551234567@s.whatsapp.net"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	handler.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 without auth, got %d", resp.Code)
+	}
+}
+
 func TestHandleMessage_RegularMessageDoesNotMarkDeleted(t *testing.T) {
 	client := newTestClient(&mockLIDStore{})
 	ms := newTestMessageStore(t)

--- a/whatsapp-mcp-server/main.py
+++ b/whatsapp-mcp-server/main.py
@@ -35,6 +35,9 @@ from whatsapp import (
     list_messages as whatsapp_list_messages,
 )
 from whatsapp import (
+    mark_messages_read as whatsapp_mark_messages_read,
+)
+from whatsapp import (
     msg_to_dict,
 )
 from whatsapp import (
@@ -364,6 +367,31 @@ def send_reaction(
         A dictionary containing success status and a status message
     """
     success, status_message = whatsapp_send_reaction(recipient, message_id, emoji, from_me, sender_jid)
+    return {"success": success, "message": status_message}
+
+
+@mcp.tool()
+def mark_messages_read(
+    message_ids: list[str],
+    chat_jid: str,
+    sender_jid: str = "",
+    timestamp: str | None = None,
+) -> dict[str, Any]:
+    """Mark selected WhatsApp messages as read and send read receipts.
+
+    This is an explicit external side effect. All message IDs must belong to the
+    same chat and sender.
+
+    Args:
+        message_ids: IDs of the messages to mark as read
+        chat_jid: JID of the chat containing the messages
+        sender_jid: JID or bare phone number of the original sender; required for groups
+        timestamp: Optional RFC 3339 read timestamp; defaults to the current time
+
+    Returns:
+        A dictionary containing success status and a status message
+    """
+    success, status_message = whatsapp_mark_messages_read(message_ids, chat_jid, sender_jid, timestamp)
     return {"success": success, "message": status_message}
 
 

--- a/whatsapp-mcp-server/tests/test_bridge_auth.py
+++ b/whatsapp-mcp-server/tests/test_bridge_auth.py
@@ -82,6 +82,7 @@ def test_send_message_without_token_surfaces_bridge_401(monkeypatch, tmp_path):
         ("send_audio_message", ("12025551234", "FILE"), "/send"),
         ("download_media", ("msg-id", "12025551234@s.whatsapp.net"), "/download"),
         ("send_reaction", ("12025551234@s.whatsapp.net", "3AABCDEF01234567", "👍"), "/react"),
+        ("mark_messages_read", (["3AABCDEF01234567"], "12025551234@s.whatsapp.net"), "/mark-read"),
     ],
 )
 def test_bridge_post_helpers_include_auth_headers(monkeypatch, tmp_path, func_name, args, expected_suffix):
@@ -163,6 +164,55 @@ def test_send_reaction_missing_message_id_returns_error():
     success, msg = whatsapp.send_reaction("12025551234@s.whatsapp.net", "", "👍")
     assert success is False
     assert "Message ID" in msg
+
+
+def test_mark_messages_read_posts_correct_payload(monkeypatch):
+    calls = []
+    monkeypatch.setenv("WHATSAPP_BRIDGE_TOKEN", "test-token")
+
+    def fake_post(url, json, headers=None):
+        calls.append({"url": url, "json": json, "headers": headers})
+        return DummyResponse(payload={"success": True, "message": "Messages marked as read"})
+
+    monkeypatch.setattr(whatsapp.requests, "post", fake_post)
+
+    success, message = whatsapp.mark_messages_read(
+        [" 3AABCDEF01234567 ", "3AABCDEF76543210"],
+        "120363012345678901@g.us",
+        sender_jid="15551234567@s.whatsapp.net",
+        timestamp="2026-08-11T18:30:00Z",
+    )
+
+    assert success is True
+    assert message == "Messages marked as read"
+    assert calls == [
+        {
+            "url": f"{whatsapp.WHATSAPP_API_BASE_URL}/mark-read",
+            "json": {
+                "message_ids": ["3AABCDEF01234567", "3AABCDEF76543210"],
+                "chat_jid": "120363012345678901@g.us",
+                "sender_jid": "15551234567@s.whatsapp.net",
+                "timestamp": "2026-08-11T18:30:00Z",
+            },
+            "headers": {"Authorization": "Bearer test-token"},
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    ("message_ids", "chat_jid", "sender_jid", "expected_message"),
+    [
+        ([], "12025551234@s.whatsapp.net", "", "message ID"),
+        ([""], "12025551234@s.whatsapp.net", "", "message ID"),
+        (["3AABCDEF01234567"], "", "", "Chat JID"),
+        (["3AABCDEF01234567"], "120363012345678901@g.us", "", "Sender JID"),
+    ],
+)
+def test_mark_messages_read_validates_input(message_ids, chat_jid, sender_jid, expected_message):
+    success, message = whatsapp.mark_messages_read(message_ids, chat_jid, sender_jid)
+
+    assert success is False
+    assert expected_message in message
 
 
 def test_send_message_with_quoted_reply_includes_quote_fields(monkeypatch):

--- a/whatsapp-mcp-server/whatsapp.py
+++ b/whatsapp-mcp-server/whatsapp.py
@@ -1155,6 +1155,50 @@ def send_reaction(
         return False, f"Unexpected error: {str(e)}"
 
 
+def mark_messages_read(
+    message_ids: list[str],
+    chat_jid: str,
+    sender_jid: str = "",
+    timestamp: str | None = None,
+) -> tuple[bool, str]:
+    """Mark selected messages as read through the WhatsApp bridge."""
+    try:
+        normalized_ids = [message_id.strip() for message_id in message_ids]
+        if not normalized_ids or any(not message_id for message_id in normalized_ids):
+            return False, "At least one non-empty message ID must be provided"
+        if not chat_jid:
+            return False, "Chat JID must be provided"
+        if chat_jid.endswith("@g.us") and not sender_jid:
+            return False, "Sender JID must be provided for group read receipts"
+
+        payload: dict[str, Any] = {
+            "message_ids": normalized_ids,
+            "chat_jid": chat_jid,
+        }
+        if sender_jid:
+            payload["sender_jid"] = sender_jid
+        if timestamp:
+            payload["timestamp"] = timestamp
+
+        response = requests.post(
+            f"{WHATSAPP_API_BASE_URL}/mark-read",
+            json=payload,
+            headers=_bridge_headers(),
+        )
+
+        if response.status_code == 200:
+            result = response.json()
+            return result.get("success", False), result.get("message", "Unknown response")
+        return False, f"Error: HTTP {response.status_code} - {response.text}"
+
+    except requests.RequestException as e:
+        return False, f"Request error: {str(e)}"
+    except json.JSONDecodeError:
+        return False, f"Error parsing response: {response.text}"
+    except Exception as e:
+        return False, f"Unexpected error: {str(e)}"
+
+
 def download_media(message_id: str, chat_jid: str) -> str | None:
     """Download media from a message and return the local file path.
 


### PR DESCRIPTION
## Summary

- Add an authenticated `/api/mark-read` bridge endpoint backed by `whatsmeow.Client.MarkRead`.
- Expose an explicit `mark_messages_read` MCP tool; listing or searching messages remains side-effect free.
- Validate message IDs, chat and sender JIDs, group participants, RFC 3339 timestamps, and bridge connectivity.

## Type of change

- [ ] `fix` — bug fix
- [x] `feat` — new feature
- [ ] `chore` / `docs` / `ci` / `refactor` / `test` / `perf`
- [ ] Breaking change (`!` in commit, or `BREAKING CHANGE:` in body)

## Scope check

- [x] This change fits the `ROADMAP.md` MCP correctness scope and was proposed in #199.
- [x] PR is focused on one concern.
- [x] PR is under ~300 changed lines.

## Linked issues

Closes #199.

This sends outbound receipts and is separate from the inbound read-state persistence in #194 / #155.

## Testing

- [x] Added or updated tests
- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run pytest -v` — 80 passed
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `golangci-lint v2.7.1` — 0 issues
- [ ] Manually exercised the external read-receipt side effect

## Docs

- [x] Updated `README.md`
- [x] Updated the tool description in `whatsapp-mcp-server/main.py`
- [x] No contributor instructions or environment variables changed

## Risk / rollback

The endpoint and MCP tool are additive and require an explicit call. Reverting the three commits removes the feature without changing either SQLite schema.
