### PR TITLE
fix: harden read-state observe/act after #155 and #201

### DIFF
--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -339,7 +339,8 @@ func (store *MessageStore) MigrateLegacyLIDChatsToPhoneJIDs(whatsappDBPath strin
 					FROM messages msg
 					WHERE msg.chat_jid = m.lid_jid
 				)
-			) AS source_last_message_time
+			) AS source_last_message_time,
+			c.last_read_time AS source_last_read_time
 		FROM tmp_lid_to_phone m
 		LEFT JOIN chats c ON c.jid = m.lid_jid;
 	`); err != nil {
@@ -364,7 +365,8 @@ func (store *MessageStore) MigrateLegacyLIDChatsToPhoneJIDs(whatsappDBPath strin
 				),
 				substr(c.phone_jid, 1, instr(c.phone_jid, '@') - 1)
 			) AS source_name,
-			MAX(c.source_last_message_time) AS source_last_message_time
+			MAX(c.source_last_message_time) AS source_last_message_time,
+			MAX(c.source_last_read_time) AS source_last_read_time
 		FROM tmp_lid_chat_candidates c
 		GROUP BY c.phone_jid;
 	`); err != nil {
@@ -372,8 +374,8 @@ func (store *MessageStore) MigrateLegacyLIDChatsToPhoneJIDs(whatsappDBPath strin
 	}
 
 	if _, err := tx.Exec(`
-		INSERT OR IGNORE INTO chats (jid, name, last_message_time)
-		SELECT phone_jid, source_name, source_last_message_time
+		INSERT OR IGNORE INTO chats (jid, name, last_message_time, last_read_time)
+		SELECT phone_jid, source_name, source_last_message_time, source_last_read_time
 		FROM tmp_lid_chat_meta;
 	`); err != nil {
 		return fmt.Errorf("failed to upsert destination chat rows: %w", err)
@@ -411,6 +413,28 @@ func (store *MessageStore) MigrateLegacyLIDChatsToPhoneJIDs(whatsappDBPath strin
 					WHERE m.phone_jid = chats.jid
 				)
 				ELSE last_message_time
+			END,
+			last_read_time = CASE
+				WHEN (
+					SELECT m.source_last_read_time
+					FROM tmp_lid_chat_meta m
+					WHERE m.phone_jid = chats.jid
+				) IS NULL THEN last_read_time
+				WHEN last_read_time IS NULL THEN (
+					SELECT m.source_last_read_time
+					FROM tmp_lid_chat_meta m
+					WHERE m.phone_jid = chats.jid
+				)
+				WHEN (
+					SELECT m.source_last_read_time
+					FROM tmp_lid_chat_meta m
+					WHERE m.phone_jid = chats.jid
+				) > last_read_time THEN (
+					SELECT m.source_last_read_time
+					FROM tmp_lid_chat_meta m
+					WHERE m.phone_jid = chats.jid
+				)
+				ELSE last_read_time
 			END
 		WHERE jid IN (SELECT phone_jid FROM tmp_lid_chat_meta);
 	`); err != nil {
@@ -704,6 +728,84 @@ func (store *MessageStore) GetMessageIsFromMe(id, chatJID string) (*bool, error)
 		return nil, err
 	}
 	return &isFromMe, nil
+}
+
+// bareSenderUser normalizes a phone/LID or full JID to the bare user part
+// stored in messages.sender.
+func bareSenderUser(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexByte(s, '@'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+// ValidateInboundMarkRead checks that every message ID exists in chatJID, is
+// inbound, and belongs to the expected sender before we send a read receipt.
+// senderHint may be bare or a full JID; when empty (DM), the chat user is used.
+func (store *MessageStore) ValidateInboundMarkRead(chatJID, senderHint string, ids []string) error {
+	expected := bareSenderUser(senderHint)
+	if expected == "" {
+		if jid, err := types.ParseJID(chatJID); err == nil {
+			expected = jid.User
+		}
+	}
+	if expected == "" {
+		return fmt.Errorf("could not determine expected sender for chat %q", chatJID)
+	}
+
+	for _, id := range ids {
+		var sender string
+		var isFromMe bool
+		err := store.db.QueryRow(
+			`SELECT sender, is_from_me FROM messages WHERE id = ? AND chat_jid = ?`,
+			id, chatJID,
+		).Scan(&sender, &isFromMe)
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("message %q not found in chat %q", id, chatJID)
+		}
+		if err != nil {
+			return err
+		}
+		if isFromMe {
+			return fmt.Errorf("message %q is outbound; only inbound messages can be marked read", id)
+		}
+		if bareSenderUser(sender) != expected {
+			return fmt.Errorf("message %q sender %q does not match %q", id, sender, expected)
+		}
+	}
+	return nil
+}
+
+// MaxMessageTimestamp returns the latest stored timestamp among the given
+// message IDs in chatJID. ok is false when none of the IDs are present.
+func (store *MessageStore) MaxMessageTimestamp(chatJID string, ids []string) (time.Time, bool, error) {
+	if len(ids) == 0 {
+		return time.Time{}, false, nil
+	}
+	placeholders := make([]string, len(ids))
+	args := make([]any, 0, 1+len(ids))
+	args = append(args, chatJID)
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args = append(args, id)
+	}
+	var raw any
+	err := store.db.QueryRow(
+		`SELECT MAX(timestamp) FROM messages WHERE chat_jid = ? AND id IN (`+strings.Join(placeholders, ",")+`)`,
+		args...,
+	).Scan(&raw)
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	if raw == nil {
+		return time.Time{}, false, nil
+	}
+	ts := anchorTime(raw)
+	if ts.IsZero() {
+		return time.Time{}, false, fmt.Errorf("unparseable message timestamp %v", raw)
+	}
+	return ts, true, nil
 }
 
 // Store a message in the database
@@ -2315,6 +2417,13 @@ func newRESTMux(client *whatsmeow.Client, messageStore *MessageStore, port int, 
 			return
 		}
 
+		// Validate against the storage (phone-form) chat JID before any
+		// external side effect. LID rewrite happens only for the receipt.
+		if err := messageStore.ValidateInboundMarkRead(req.ChatJID, req.SenderJID, req.MessageIDs); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
 		// MCP storage normalizes chats/senders to phone JIDs; MarkRead routes
 		// the receipt `to`/`participant` as given, so resolve PN -> LID the
 		// same way sendWhatsAppMessage does or migrated contacts silently fail.
@@ -2336,6 +2445,18 @@ func newRESTMux(client *whatsmeow.Client, messageStore *MessageStore, port int, 
 			_ = json.NewEncoder(w).Encode(SendMessageResponse{Success: false, Message: err.Error()})
 			return
 		}
+
+		// Advance the local read marker immediately so list_chats unread
+		// clears without waiting for the self-read receipt round-trip.
+		localReadAt := readAt
+		if ts, ok, tsErr := messageStore.MaxMessageTimestamp(req.ChatJID, req.MessageIDs); tsErr == nil && ok {
+			localReadAt = ts
+		}
+		if err := messageStore.MarkChatRead(req.ChatJID, localReadAt); err != nil {
+			// Receipt already sent; log but still report success to the caller.
+			fmt.Printf("Warning: failed to persist local read marker for %s: %v\n", req.ChatJID, err)
+		}
+
 		_ = json.NewEncoder(w).Encode(SendMessageResponse{Success: true, Message: "Messages marked as read"})
 	}))
 
@@ -2728,7 +2849,20 @@ func main() {
 			// from "latest message is inbound". Only our own reads count.
 			if isSelfReadReceipt(v) {
 				chatJID := resolveLIDChat(client, v.Chat, v.SenderAlt, v.RecipientAlt, v.IsFromMe).String()
-				if err := messageStore.MarkChatRead(chatJID, v.Timestamp); err != nil {
+				// Prefer the acknowledged messages' timestamps over the
+				// receipt event time so out-of-order delivery cannot advance
+				// the marker past an unread message.
+				readAt := v.Timestamp
+				ids := make([]string, len(v.MessageIDs))
+				for i, id := range v.MessageIDs {
+					ids[i] = string(id)
+				}
+				if ts, ok, err := messageStore.MaxMessageTimestamp(chatJID, ids); err != nil {
+					logger.Warnf("Failed to look up read receipt message times for %s: %v", chatJID, err)
+				} else if ok {
+					readAt = ts
+				}
+				if err := messageStore.MarkChatRead(chatJID, readAt); err != nil {
 					logger.Warnf("Failed to mark chat %s read: %v", chatJID, err)
 				}
 			}
@@ -3226,11 +3360,13 @@ func handleHistorySync(client *whatsmeow.Client, messageStore *MessageStore, his
 			timestamp := time.Unix(int64(ts), 0)
 
 			_ = messageStore.StoreChat(chatJID, name, timestamp)
-			// Backfill read state: a conversation WhatsApp reports as fully
-			// read (no unread count, not manually flagged) is read up to its
-			// last message. Conversations with genuine unread are left
-			// unmarked so they correctly stay "awaiting".
-			if conversation.GetUnreadCount() == 0 && !conversation.GetMarkedAsUnread() {
+			// Backfill read state only when WhatsApp explicitly reports unread
+			// metadata. Sparse history-sync chunks omit UnreadCount; the
+			// generated getter then returns 0 and would permanently mark the
+			// chat read under the monotonic merge.
+			if conversation.UnreadCount != nil &&
+				conversation.GetUnreadCount() == 0 &&
+				!conversation.GetMarkedAsUnread() {
 				if err := messageStore.MarkChatRead(chatJID, timestamp); err != nil {
 					logger.Warnf("Failed to backfill read state for %s: %v", chatJID, err)
 				}

--- a/whatsapp-bridge/main_test.go
+++ b/whatsapp-bridge/main_test.go
@@ -1109,9 +1109,9 @@ func TestMigrateLegacyLIDChatsToPhoneJIDs_MigratesAndIsIdempotent(t *testing.T) 
 	phoneJID := "222@s.whatsapp.net"
 
 	_, err = ms.db.Exec(`
-		INSERT INTO chats (jid, name, last_message_time) VALUES
-			(?, 'Legacy LID Name', '2026-03-01T10:00:00Z'),
-			(?, '', '2026-03-01T09:00:00Z');
+		INSERT INTO chats (jid, name, last_message_time, last_read_time) VALUES
+			(?, 'Legacy LID Name', '2026-03-01T10:00:00Z', '2026-03-01T09:30:00Z'),
+			(?, '', '2026-03-01T09:00:00Z', '2026-03-01T08:00:00Z');
 
 		INSERT INTO messages (id, chat_jid, sender, content, timestamp, is_from_me, media_type, filename, url, media_key, file_sha256, file_enc_sha256, file_length) VALUES
 			('dup', ?, 'alice', 'lid duplicate', '2026-03-01T10:00:00Z', 0, '', '', '', NULL, NULL, NULL, 0),
@@ -1152,6 +1152,14 @@ func TestMigrateLegacyLIDChatsToPhoneJIDs_MigratesAndIsIdempotent(t *testing.T) 
 	}
 	if phoneTime != "2026-03-01T10:00:00Z" {
 		t.Fatalf("expected phone chat last_message_time to be the latest (from LID chat), got %q", phoneTime)
+	}
+
+	phoneRead, readFound := queryChatLastReadTime(ms, phoneJID)
+	if !readFound || phoneRead == "" {
+		t.Fatalf("expected phone chat last_read_time to be preserved, got %q found=%v", phoneRead, readFound)
+	}
+	if phoneRead != "2026-03-01T09:30:00Z" {
+		t.Fatalf("expected last_read_time merged to later LID marker, got %q", phoneRead)
 	}
 
 	if err := ms.MigrateLegacyLIDChatsToPhoneJIDs(whatsappDBPath, logger); err != nil {
@@ -2313,7 +2321,18 @@ func TestMarkReadHandler_InvalidRequests_Return400(t *testing.T) {
 
 func TestMarkReadHandler_Disconnected_Returns503(t *testing.T) {
 	const token = "supersecrettoken1234567890abcdef"
-	handler := newRESTMux(newTestClient(&mockLIDStore{}), newTestMessageStore(t), 8080, token, nil)
+	ms := newTestMessageStore(t)
+	chatJID := "120363012345678901@g.us"
+	sender := "15551234567"
+	msgID := "3AABCDEF01234567"
+	if _, err := ms.db.Exec(
+		`INSERT INTO messages (id, chat_jid, sender, content, timestamp, is_from_me)
+		 VALUES (?, ?, ?, 'hi', ?, 0)`,
+		msgID, chatJID, sender, time.Unix(1710000000, 0),
+	); err != nil {
+		t.Fatalf("seed message: %v", err)
+	}
+	handler := newRESTMux(newTestClient(&mockLIDStore{}), ms, 8080, token, nil)
 
 	body := `{"message_ids":["3AABCDEF01234567"],"chat_jid":"120363012345678901@g.us","sender_jid":"15551234567","timestamp":"2026-08-11T18:30:00Z"}`
 	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:8080/api/mark-read", strings.NewReader(body))
@@ -2324,7 +2343,7 @@ func TestMarkReadHandler_Disconnected_Returns503(t *testing.T) {
 	handler.ServeHTTP(resp, req)
 
 	if resp.Code != http.StatusServiceUnavailable {
-		t.Errorf("expected 503 for disconnected client, got %d", resp.Code)
+		t.Errorf("expected 503 for disconnected client, got %d body=%s", resp.Code, resp.Body.String())
 	}
 }
 
@@ -2383,6 +2402,65 @@ func TestResolveRecipientJID_ForMarkReadTargets(t *testing.T) {
 	}
 	if gotGroup != group {
 		t.Fatalf("expected group JID unchanged, got %s", gotGroup)
+	}
+}
+
+func TestValidateInboundMarkRead(t *testing.T) {
+	ms := newTestMessageStore(t)
+	chat := "15551234567@s.whatsapp.net"
+	group := "120363012345678901@g.us"
+	if _, err := ms.db.Exec(`
+		INSERT INTO messages (id, chat_jid, sender, content, timestamp, is_from_me) VALUES
+			('in-dm', ?, '15551234567', 'hi', ?, 0),
+			('out-dm', ?, '15559876543', 'yo', ?, 1),
+			('in-group', ?, '15557654321', 'hi', ?, 0);
+	`, chat, time.Unix(1710000000, 0), chat, time.Unix(1710000001, 0), group, time.Unix(1710000002, 0)); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := ms.ValidateInboundMarkRead(chat, "", []string{"in-dm"}); err != nil {
+		t.Fatalf("DM validate: %v", err)
+	}
+	if err := ms.ValidateInboundMarkRead(group, "15557654321@s.whatsapp.net", []string{"in-group"}); err != nil {
+		t.Fatalf("group validate: %v", err)
+	}
+	if err := ms.ValidateInboundMarkRead(chat, "", []string{"missing"}); err == nil {
+		t.Fatal("expected missing message error")
+	}
+	if err := ms.ValidateInboundMarkRead(chat, "", []string{"out-dm"}); err == nil {
+		t.Fatal("expected outbound message error")
+	}
+	if err := ms.ValidateInboundMarkRead(group, "15551234567", []string{"in-group"}); err == nil {
+		t.Fatal("expected sender mismatch error")
+	}
+}
+
+func TestMaxMessageTimestamp(t *testing.T) {
+	ms := newTestMessageStore(t)
+	chat := "15551234567@s.whatsapp.net"
+	early := time.Unix(1710000000, 0).UTC()
+	late := time.Unix(1710009999, 0).UTC()
+	if _, err := ms.db.Exec(`
+		INSERT INTO messages (id, chat_jid, sender, content, timestamp, is_from_me) VALUES
+			('a', ?, '15551234567', 'early', ?, 0),
+			('b', ?, '15551234567', 'late', ?, 0);
+	`, chat, early, chat, late); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	got, ok, err := ms.MaxMessageTimestamp(chat, []string{"a", "b"})
+	if err != nil || !ok {
+		t.Fatalf("MaxMessageTimestamp: ok=%v err=%v", ok, err)
+	}
+	if !got.Equal(late) {
+		t.Fatalf("expected %v, got %v", late, got)
+	}
+	_, ok, err = ms.MaxMessageTimestamp(chat, []string{"missing"})
+	if err != nil {
+		t.Fatalf("missing ids: %v", err)
+	}
+	if ok {
+		t.Fatal("expected ok=false for missing ids")
 	}
 }
 

--- a/whatsapp-mcp-server/tests/test_read_state.py
+++ b/whatsapp-mcp-server/tests/test_read_state.py
@@ -152,3 +152,39 @@ def test_reads_work_against_store_without_read_state_column(legacy_db):
     chat = whatsapp.get_chat("read@s.whatsapp.net")
     assert chat["last_read_time"] is None
     assert chat["unread"] is True
+
+
+def test_list_chats_dedupes_timestamp_ties(tmp_path, monkeypatch):
+    """Two messages sharing last_message_time must not duplicate the chat row."""
+    db_path = tmp_path / "tie.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(SCHEMA_WITH_READ_STATE + MESSAGES_SCHEMA)
+    conn.execute(
+        "INSERT INTO chats (jid, name, last_message_time, last_read_time) VALUES (?, ?, ?, NULL)",
+        ("tie@s.whatsapp.net", "Tie", "2024-01-15 10:30:00+00:00"),
+    )
+    conn.execute(
+        """INSERT INTO messages (id, chat_jid, sender, content, timestamp, is_from_me)
+           VALUES ('aaa', 'tie@s.whatsapp.net', 'peer', 'first', '2024-01-15 10:30:00+00:00', 0),
+                  ('zzz', 'tie@s.whatsapp.net', 'peer', 'second', '2024-01-15 10:30:00+00:00', 1)"""
+    )
+    conn.commit()
+    conn.close()
+    monkeypatch.setattr(whatsapp, "MESSAGES_DB_PATH", str(db_path))
+
+    chats = whatsapp.list_chats(limit=10, include_last_message=False)
+    assert len(chats) == 1
+    # Deterministic tie-break prefers higher id ('zzz'), which is from_me.
+    assert chats[0]["last_is_from_me"] == 1
+    assert chats[0]["unread"] is False
+
+
+def test_unread_false_when_last_message_row_missing():
+    chat = whatsapp.Chat(
+        jid="x@s.whatsapp.net",
+        name="X",
+        last_message_time=whatsapp.datetime.fromisoformat("2024-01-15T10:30:00+00:00"),
+        last_is_from_me=None,
+        last_read_time=None,
+    )
+    assert chat.unread is False

--- a/whatsapp-mcp-server/whatsapp.py
+++ b/whatsapp-mcp-server/whatsapp.py
@@ -89,8 +89,14 @@ class Chat:
         or another linked device is not reported. Without one (older bridge,
         or a chat WhatsApp never reported a read for) it degrades to the old
         heuristic: unread if the last message is inbound.
+
+        A missing last-message row (`last_is_from_me is None`) cannot establish
+        direction — protocol/unsupported events can advance last_message_time
+        without storing a message — so those chats are not reported as unread.
         """
-        if self.last_message_time is None or self.last_is_from_me:
+        if self.last_message_time is None or self.last_is_from_me is None:
+            return False
+        if self.last_is_from_me:
             return False
         if self.last_read_time is None:
             return True
@@ -178,6 +184,25 @@ def _last_read_time_select(cursor: sqlite3.Cursor, table_alias: str) -> str:
     """
     columns = {row[1] for row in cursor.execute("PRAGMA table_info(chats)").fetchall()}
     return f"{table_alias}.last_read_time" if "last_read_time" in columns else "NULL"
+
+
+def _last_message_join(chat_alias: str, msg_alias: str) -> str:
+    """Deterministic single-row join to the chat's latest message.
+
+    Multiple messages can share last_message_time (history sync is second-
+    resolution). Joining solely on timestamp would duplicate chat rows and
+    make last_is_from_me / unread non-deterministic; pick one id as tie-break.
+    """
+    return f"""
+            LEFT JOIN messages {msg_alias} ON {chat_alias}.jid = {msg_alias}.chat_jid
+                AND {msg_alias}.id = (
+                    SELECT m.id FROM messages m
+                    WHERE m.chat_jid = {chat_alias}.jid
+                      AND m.timestamp = {chat_alias}.last_message_time
+                    ORDER BY m.id DESC
+                    LIMIT 1
+                )
+    """
 
 
 def _sender_aliases(value: str) -> list[str]:
@@ -661,8 +686,7 @@ def list_chats(
                 messages.is_from_me as last_is_from_me,
                 {_last_read_time_select(cursor, "chats")}
             FROM chats
-            LEFT JOIN messages ON chats.jid = messages.chat_jid
-                AND chats.last_message_time = messages.timestamp
+            {_last_message_join("chats", "messages")}
         """
         ]
 
@@ -812,8 +836,7 @@ def get_contact_chats(jid: str, limit: int = 20, page: int = 0) -> list[dict[str
                 last_msg.is_from_me as last_is_from_me,
                 {_last_read_time_select(cursor, "c")}
             FROM chats c
-            LEFT JOIN messages last_msg ON c.jid = last_msg.chat_jid
-                AND c.last_message_time = last_msg.timestamp
+            {_last_message_join("c", "last_msg")}
             WHERE EXISTS (
                 SELECT 1
                 FROM messages contact_msg
@@ -938,8 +961,7 @@ def get_chat(chat_jid: str, include_last_message: bool = True) -> dict[str, Any]
                 m.is_from_me as last_is_from_me,
                 {_last_read_time_select(cursor, "c")}
             FROM chats c
-            LEFT JOIN messages m ON c.jid = m.chat_jid
-                AND c.last_message_time = m.timestamp
+            {_last_message_join("c", "m")}
             WHERE c.jid = ?
         """
 
@@ -985,8 +1007,7 @@ def get_direct_chat_by_contact(sender_phone_number: str) -> dict[str, Any] | Non
                 m.is_from_me as last_is_from_me,
                 {_last_read_time_select(cursor, "c")}
             FROM chats c
-            LEFT JOIN messages m ON c.jid = m.chat_jid
-                AND c.last_message_time = m.timestamp
+            {_last_message_join("c", "m")}
             WHERE c.jid LIKE ? AND c.jid NOT LIKE '%@g.us'
             LIMIT 1
         """,


### PR DESCRIPTION
## Summary

Same-day follow-up after merging [#155](https://github.com/verygoodplugins/whatsapp-mcp/pull/155) and [#201](https://github.com/verygoodplugins/whatsapp-mcp/pull/201) (#200). Lands the Codex P2s we deferred plus observe/act glue.

- **#200 P2:** validate message IDs exist in-chat, inbound, matching sender before `MarkRead`
- **#155 P2:** LID migration monotonically merges `last_read_time`
- **#155 P2:** history-sync backfill only when `UnreadCount` is present
- **#155 P2:** deterministic last-message join (timestamp ties)
- **#155 P2:** `unread` false when `last_is_from_me is None`
- **#155 P2:** receipt markers use max acknowledged message timestamp
- **Glue:** successful `/api/mark-read` also advances local `chats.last_read_time`

## Test plan

- [x] `go test ./...`
- [x] `uv run pytest -q` (89 passed)
- [x] `uv run ruff check .`
- [ ] CI green