### PR TITLE
feat(bridge): add outbound webhook opt-out

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,10 @@ WHATSAPP_BRIDGE_PORT=8080
 # that same token — see WHATSAPP_BRIDGE_TOKEN below.
 WEBHOOK_URL=http://localhost:8769/whatsapp/webhook
 
+# Set to false to disable outbound webhooks entirely. Leaving WEBHOOK_URL empty
+# does not disable them: it falls back to the default above.
+WEBHOOK_ENABLED=true
+
 # Forward messages sent by self (true/false)
 FORWARD_SELF=false
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,8 @@ A failing blocking job is a hard block — fix it or explain in the PR why it's 
 | `WHATSAPP_MCP_TRANSPORT` | `stdio` | MCP transport to serve clients: `stdio`, `http`, or `sse` |
 | `WHATSAPP_MCP_HOST` | `127.0.0.1` | Bind address for the `http`/`sse` transports |
 | `WHATSAPP_MCP_PORT` | `8000` | Port for the `http`/`sse` transports |
-| `WEBHOOK_URL` | `http://localhost:8769/whatsapp/webhook` | Outgoing webhook for incoming messages (empty = disabled) |
+| `WEBHOOK_URL` | `http://localhost:8769/whatsapp/webhook` | Outgoing webhook for incoming messages (empty falls back to this default) |
+| `WEBHOOK_ENABLED` | `true` | Set to `false` to disable outbound webhooks entirely |
 | `FORWARD_SELF` | `true` | Whether self-sent messages are forwarded (`getEnvBool` default; set `FORWARD_SELF=false` to disable) |
 | `WHATSAPP_PARENT_WATCHDOG_S` | `30` | Stdio parent-liveness poll interval (seconds). Exits when the original parent is gone (POSIX reparent). Soft stdin EOF alone does not exit. |
 

--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@ Copy `.env.example` to `.env` and configure as needed:
 | ---------------------- | ---------------------------------------- | -------------------------------------------- |
 | `WHATSAPP_BRIDGE_PORT` | `8080`                                   | Port for Go bridge REST API                  |
 | `WEBHOOK_URL`          | `http://localhost:8769/whatsapp/webhook` | Webhook for incoming messages                |
+| `WEBHOOK_ENABLED`      | `true`                                   | Set to `false` to disable outbound webhooks  |
 | `FORWARD_SELF`         | `true`                                   | Forward messages sent by self                |
 | `WHATSAPP_DB_PATH`     | `../whatsapp-bridge/store/messages.db`   | Path to SQLite database                      |
 | `WHATSMEOW_DB_PATH`    | `../whatsapp-bridge/store/whatsapp.db`   | whatsmeow DB used for LID ↔ phone resolution |

--- a/scripts/install-launchd-macos.sh
+++ b/scripts/install-launchd-macos.sh
@@ -101,7 +101,7 @@ write_export "WHATSAPP_API_URL" "$API_URL"
 write_export "WHATSAPP_MCP_LOG_DIR" "$LOG_DIR"
 write_export "WHATSAPP_MCP_STATE_DIR" "$STATE_DIR"
 
-for optional_var in WEBHOOK_URL FORWARD_SELF WHATSAPP_BRIDGE_TOKEN WHATSAPP_MEDIA_ROOTS; do
+for optional_var in WEBHOOK_URL WEBHOOK_ENABLED FORWARD_SELF WHATSAPP_BRIDGE_TOKEN WHATSAPP_MEDIA_ROOTS; do
   if [[ -v "$optional_var" ]]; then
     write_export "$optional_var" "${(P)optional_var}"
   fi

--- a/scripts/tests/test-launchd-macos.sh
+++ b/scripts/tests/test-launchd-macos.sh
@@ -119,6 +119,7 @@ if [ "${FAKE_CURL_EMPTY:-0}" = "1" ]; then
   exit 7
 fi
 printf '%s\n' "${FAKE_CURL_RESPONSE:-{\"status\":\"ok\",\"connected\":true}}"
+printf '%s\n' "${FAKE_CURL_STATUS:-200}"
 exit "${FAKE_CURL_EXIT:-0}"
 EOF
 
@@ -212,6 +213,7 @@ test_install_preserves_optional_env_values() {
     FAKE_CMD_LOG="$tmp/cmd.log" \
     WHATSAPP_BRIDGE_PORT="9090" \
     WEBHOOK_URL="http://127.0.0.1:8769/whatsapp/webhook" \
+    WEBHOOK_ENABLED="false" \
     FORWARD_SELF="true" \
     WHATSAPP_BRIDGE_TOKEN="test token with spaces" \
     WHATSAPP_MEDIA_ROOTS="/tmp/outbox:/tmp/other outbox" \
@@ -222,6 +224,7 @@ test_install_preserves_optional_env_values() {
   assert_contains "$support/launchd.env" "export WHATSAPP_BRIDGE_PORT='9090'"
   assert_contains "$support/launchd.env" "export WHATSAPP_API_URL='http://127.0.0.1:9090/api'"
   assert_contains "$support/launchd.env" "export WEBHOOK_URL='http://127.0.0.1:8769/whatsapp/webhook'"
+  assert_contains "$support/launchd.env" "export WEBHOOK_ENABLED='false'"
   assert_contains "$support/launchd.env" "export FORWARD_SELF='true'"
   assert_contains "$support/launchd.env" "export WHATSAPP_BRIDGE_TOKEN='test token with spaces'"
   assert_contains "$support/launchd.env" "export WHATSAPP_MEDIA_ROOTS='/tmp/outbox:/tmp/other outbox'"

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -1946,14 +1946,19 @@ func handleMessage(client *whatsmeow.Client, messageStore *MessageStore, msg *ev
 		}
 	}
 
-	// For image messages, download media synchronously so we can include the base64
-	// payload in the webhook. Other media types (video, audio, document) are still
-	// downloaded asynchronously since they are not passed to the AI vision pipeline.
+	// Avoid webhook-only image work when no webhook will receive the message. Media
+	// still downloads asynchronously in that case so it remains available to MCP
+	// tools, but message handling never blocks on a disabled outbound webhook.
+	shouldForward := webhooksEnabled() && (forwardSelfMessages || !msg.Info.IsFromMe)
+
+	// For image messages that will be forwarded, download media synchronously so we
+	// can include the base64 payload in the webhook. Other media types (and images
+	// when webhook forwarding is disabled) download asynchronously for caching.
 	var imageDownloadPath string
 	var imageMimeType string
-	if mediaType == "image" && url != "" && len(mediaKey) > 0 {
+	if mediaType == "image" && url != "" && len(mediaKey) > 0 && shouldForward {
 		logger.Infof("Downloading image media for message %s (synchronous)", msg.Info.ID)
-		success, _, _, dlPath, dlErr := downloadMedia(client, messageStore, msg.Info.ID, chatJID)
+		success, _, _, dlPath, dlErr := downloadMediaForMessage(client, messageStore, msg.Info.ID, chatJID)
 		if success && dlErr == nil {
 			imageDownloadPath = dlPath
 			// Detect MIME type by sniffing the actual file bytes rather than
@@ -1973,14 +1978,14 @@ func handleMessage(client *whatsmeow.Client, messageStore *MessageStore, msg *ev
 			logger.Warnf("❌ Image download failed: %v", dlErr)
 			// Fall back to async download so media is cached for future MCP tool calls
 			go func() {
-				_, _, _, _, _ = downloadMedia(client, messageStore, msg.Info.ID, chatJID)
+				_, _, _, _, _ = downloadMediaForMessage(client, messageStore, msg.Info.ID, chatJID)
 			}()
 		}
-	} else if mediaType != "" && mediaType != "image" && url != "" && len(mediaKey) > 0 {
-		// Non-image media: async download for caching only (not sent to vision pipeline)
+	} else if mediaType != "" && url != "" && len(mediaKey) > 0 {
+		// Media that is not included in a webhook payload: async download for caching.
 		logger.Infof("Auto-downloading %s media for message %s", mediaType, msg.Info.ID)
 		go func() {
-			success, _, _, downloadPath, err := downloadMedia(client, messageStore, msg.Info.ID, chatJID)
+			success, _, _, downloadPath, err := downloadMediaForMessage(client, messageStore, msg.Info.ID, chatJID)
 			if success && err == nil {
 				logger.Infof("✅ Auto-downloaded media: %s", downloadPath)
 			} else {
@@ -1993,7 +1998,6 @@ func handleMessage(client *whatsmeow.Client, messageStore *MessageStore, msg *ev
 	// Forward self-messages when FORWARD_SELF=true.
 	// Always forward image messages (even without a text caption) so the AI vision
 	// pipeline can analyse the image content.
-	shouldForward := forwardSelfMessages || !msg.Info.IsFromMe
 	hasText := content != ""
 	hasImage := mediaType == "image"
 
@@ -2229,6 +2233,10 @@ func downloadMedia(client *whatsmeow.Client, messageStore *MessageStore, message
 	fmt.Printf("Successfully downloaded %s media to %s (%d bytes)\n", mediaType, absPath, len(mediaData))
 	return true, mediaType, filename, absPath, nil
 }
+
+// downloadMediaForMessage allows message-handling tests to verify whether a
+// download blocks event processing without changing production behavior.
+var downloadMediaForMessage = downloadMedia
 
 // Extract direct path from a WhatsApp media URL
 func extractDirectPathFromURL(url string) string {
@@ -2679,6 +2687,16 @@ func startRESTServer(client *whatsmeow.Client, messageStore *MessageStore, port 
 	}()
 }
 
+func webhookStartupMessage(forwardSelf bool) string {
+	if !webhooksEnabled() {
+		return "WEBHOOK_ENABLED=false: outbound webhooks disabled"
+	}
+	if forwardSelf {
+		return "FORWARD_SELF enabled: forwarding self messages to webhook"
+	}
+	return "FORWARD_SELF disabled: self messages will NOT be forwarded"
+}
+
 func main() {
 	flag.Parse()
 
@@ -2686,11 +2704,7 @@ func main() {
 	logger := waLog.Stdout("Client", "DEBUG", true)
 	logger.Infof("Starting WhatsApp client...")
 
-	if forwardSelfMessages {
-		logger.Infof("FORWARD_SELF enabled: forwarding self messages to webhook")
-	} else {
-		logger.Infof("FORWARD_SELF disabled: self messages will NOT be forwarded")
-	}
+	logger.Infof("%s", webhookStartupMessage(forwardSelfMessages))
 
 	// Create database connection for storing session data
 	dbLog := waLog.Stdout("Database", "INFO", true)

--- a/whatsapp-bridge/main_test.go
+++ b/whatsapp-bridge/main_test.go
@@ -1562,6 +1562,66 @@ func TestHandleMessage_ImageWithCaption_WebhookForwarded(t *testing.T) {
 	}
 }
 
+// TestHandleMessage_WebhookDisabledDownloadsImageAsynchronously ensures the
+// webhook opt-out does not make incoming image processing wait on a download
+// solely used for the vision webhook payload.
+func TestHandleMessage_WebhookDisabledDownloadsImageAsynchronously(t *testing.T) {
+	t.Setenv("WEBHOOK_ENABLED", "false")
+
+	client := newTestClient(&mockLIDStore{})
+	ms := newTestMessageStore(t)
+	logger := testLogger()
+	msg := buildImageMessage(phonePN, phonePN, false, "")
+	msg.Message.ImageMessage.URL = proto.String("https://example.invalid/image")
+	msg.Message.ImageMessage.MediaKey = []byte("test-media-key")
+
+	originalDownload := downloadMediaForMessage
+	downloadStarted := make(chan struct{})
+	releaseDownload := make(chan struct{})
+	downloadMediaForMessage = func(_ *whatsmeow.Client, _ *MessageStore, _ string, _ string) (bool, string, string, string, error) {
+		close(downloadStarted)
+		<-releaseDownload
+		return false, "", "", "", nil
+	}
+	t.Cleanup(func() {
+		downloadMediaForMessage = originalDownload
+		select {
+		case <-releaseDownload:
+		default:
+			close(releaseDownload)
+		}
+	})
+
+	done := make(chan struct{})
+	go func() {
+		handleMessage(client, ms, msg, logger)
+		close(done)
+	}()
+
+	select {
+	case <-downloadStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for asynchronous media download")
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("message handling waited for media download while webhook was disabled")
+	}
+}
+
+func TestWebhookStartupMessage(t *testing.T) {
+	t.Setenv("WEBHOOK_ENABLED", "false")
+	if got, want := webhookStartupMessage(true), "WEBHOOK_ENABLED=false: outbound webhooks disabled"; got != want {
+		t.Errorf("disabled startup message = %q, want %q", got, want)
+	}
+
+	t.Setenv("WEBHOOK_ENABLED", "true")
+	if got, want := webhookStartupMessage(true), "FORWARD_SELF enabled: forwarding self messages to webhook"; got != want {
+		t.Errorf("enabled startup message = %q, want %q", got, want)
+	}
+}
+
 // queryCallResult returns the (result, duration_sec, reason) for a call row,
 // or empties if no row exists.
 func queryCallResult(ms *MessageStore, callID, chatJID string) (result string, duration sql.NullInt64, reason sql.NullString, found bool) {

--- a/whatsapp-bridge/webhook.go
+++ b/whatsapp-bridge/webhook.go
@@ -75,6 +75,16 @@ type WebhookPayload struct {
 
 // sendWebhookPayload marshals and POSTs a WebhookPayload to the configured webhook URL.
 func sendWebhookPayload(payload WebhookPayload) {
+	// WEBHOOK_ENABLED=false turns outbound webhooks off entirely. An empty
+	// WEBHOOK_URL cannot serve that purpose: os.Getenv cannot tell "unset"
+	// from "explicitly empty", and empty deliberately falls back to
+	// defaultWebhookURL below. Deployments with no webhook consumer would
+	// otherwise POST to that default for every message and log a connection
+	// refused error each time.
+	if !getEnvBool("WEBHOOK_ENABLED", true) {
+		return
+	}
+
 	webhookURL := os.Getenv("WEBHOOK_URL")
 	explicitlyConfigured := webhookURL != ""
 	if !explicitlyConfigured {

--- a/whatsapp-bridge/webhook.go
+++ b/whatsapp-bridge/webhook.go
@@ -73,6 +73,13 @@ type WebhookPayload struct {
 	ReactionRemoved     *bool   `json:"reactionRemoved,omitempty"`
 }
 
+// webhooksEnabled reports whether webhook processing is enabled. Keep this
+// separate from sendWebhookPayload so media callers can avoid their webhook-only
+// file work when delivery is disabled.
+func webhooksEnabled() bool {
+	return getEnvBool("WEBHOOK_ENABLED", true)
+}
+
 // sendWebhookPayload marshals and POSTs a WebhookPayload to the configured webhook URL.
 func sendWebhookPayload(payload WebhookPayload) {
 	// WEBHOOK_ENABLED=false turns outbound webhooks off entirely. An empty
@@ -81,7 +88,7 @@ func sendWebhookPayload(payload WebhookPayload) {
 	// defaultWebhookURL below. Deployments with no webhook consumer would
 	// otherwise POST to that default for every message and log a connection
 	// refused error each time.
-	if !getEnvBool("WEBHOOK_ENABLED", true) {
+	if !webhooksEnabled() {
 		return
 	}
 
@@ -153,6 +160,10 @@ func SendWebhookWithMedia(
 	quotedIsFromMe *bool, mentionedJIDs []string,
 	messageID, mediaType, mimeType, mediaFilename, localPath string,
 ) {
+	if !webhooksEnabled() {
+		return
+	}
+
 	var mediaBase64 string
 	if localPath != "" {
 		info, statErr := os.Stat(localPath)

--- a/whatsapp-bridge/webhook_test.go
+++ b/whatsapp-bridge/webhook_test.go
@@ -29,6 +29,48 @@ func setDefaultWebhookURL(t *testing.T, url string) {
 	t.Cleanup(func() { defaultWebhookURL = prev })
 }
 
+// TestSendWebhookDisabledByEnv verifies that WEBHOOK_ENABLED=false suppresses
+// outbound webhooks. An empty WEBHOOK_URL cannot express this, because empty
+// intentionally falls back to defaultWebhookURL (see
+// TestSendWebhookOmitsBridgeTokenOnImplicitDefaultURL), leaving deployments
+// with no webhook consumer no way to opt out.
+func TestSendWebhookDisabledByEnv(t *testing.T) {
+	var received bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	t.Setenv("WEBHOOK_ENABLED", "false")
+	t.Setenv("WEBHOOK_URL", srv.URL)
+
+	SendWebhook("123@s.whatsapp.net", "hi", "123@s.whatsapp.net", false, "", "", "", nil, nil)
+
+	if received {
+		t.Fatal("webhook was delivered despite WEBHOOK_ENABLED=false")
+	}
+}
+
+// TestSendWebhookEnabledByDefault guards the default: omitting WEBHOOK_ENABLED
+// must leave delivery behavior exactly as it was before the flag existed.
+func TestSendWebhookEnabledByDefault(t *testing.T) {
+	var received bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	t.Setenv("WEBHOOK_URL", srv.URL)
+
+	SendWebhook("123@s.whatsapp.net", "hi", "123@s.whatsapp.net", false, "", "", "", nil, nil)
+
+	if !received {
+		t.Fatal("webhook was not delivered with WEBHOOK_ENABLED unset")
+	}
+}
+
 // TestSendWebhookAttachesBridgeTokenHeader verifies that outbound webhook POSTs
 // carry the shared bridge token as an "X-Bridge-Token" header so the hub's
 // fail-closed inbound-auth middleware (autohub PR #898) accepts them. The token

--- a/whatsapp-bridge/webhook_test.go
+++ b/whatsapp-bridge/webhook_test.go
@@ -7,8 +7,34 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
+
+// TestMain keeps host-level opt-out configuration from silently changing tests
+// that exercise webhook delivery. Individual tests set WEBHOOK_ENABLED when
+// they need to cover an enabled or disabled value.
+func TestMain(m *testing.M) {
+	_ = os.Unsetenv("WEBHOOK_ENABLED")
+	os.Exit(m.Run())
+}
+
+func unsetWebhookEnabled(t *testing.T) {
+	t.Helper()
+	value, wasSet := os.LookupEnv("WEBHOOK_ENABLED")
+	if err := os.Unsetenv("WEBHOOK_ENABLED"); err != nil {
+		t.Fatalf("unset WEBHOOK_ENABLED: %v", err)
+	}
+	t.Cleanup(func() {
+		if wasSet {
+			_ = os.Setenv("WEBHOOK_ENABLED", value)
+		} else {
+			_ = os.Unsetenv("WEBHOOK_ENABLED")
+		}
+	})
+}
 
 // setWebhookAuthToken sets the package-level outbound webhook token for the
 // duration of a test and restores the previous value on cleanup.
@@ -55,6 +81,7 @@ func TestSendWebhookDisabledByEnv(t *testing.T) {
 // TestSendWebhookEnabledByDefault guards the default: omitting WEBHOOK_ENABLED
 // must leave delivery behavior exactly as it was before the flag existed.
 func TestSendWebhookEnabledByDefault(t *testing.T) {
+	unsetWebhookEnabled(t)
 	var received bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		received = true
@@ -68,6 +95,45 @@ func TestSendWebhookEnabledByDefault(t *testing.T) {
 
 	if !received {
 		t.Fatal("webhook was not delivered with WEBHOOK_ENABLED unset")
+	}
+}
+
+func TestSendWebhookWithMediaDisabledSkipsMediaIO(t *testing.T) {
+	var received bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	t.Setenv("WEBHOOK_ENABLED", "false")
+	t.Setenv("WEBHOOK_URL", srv.URL)
+	missingPath := filepath.Join(t.TempDir(), "missing.jpg")
+
+	readEnd, writeEnd, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdout pipe: %v", err)
+	}
+	previousStdout := os.Stdout
+	os.Stdout = writeEnd
+	SendWebhookWithMedia(
+		"123@s.whatsapp.net", "", "123@s.whatsapp.net", false,
+		"", "", "", nil, nil,
+		"message-id", "image", "image/jpeg", "missing.jpg", missingPath,
+	)
+	_ = writeEnd.Close()
+	os.Stdout = previousStdout
+	output, err := io.ReadAll(readEnd)
+	if err != nil {
+		t.Fatalf("read captured stdout: %v", err)
+	}
+	_ = readEnd.Close()
+
+	if received {
+		t.Fatal("webhook was delivered despite WEBHOOK_ENABLED=false")
+	}
+	if strings.Contains(string(output), "Could not stat media file") {
+		t.Fatalf("disabled webhook still touched media path: %s", output)
 	}
 }
 


### PR DESCRIPTION
Supersedes #195 with its reviewed fixes.

Adds `WEBHOOK_ENABLED=false` while preserving the current default. The macOS launchd installer preserves the setting, disabled media webhooks skip webhook-only file I/O, and test isolation keeps host configuration from suppressing expected delivery tests.

Tests:
- `WEBHOOK_ENABLED=false go test ./...`
- `go test ./...`
- `go build ./...`
- `golangci-lint run`
- `zsh scripts/tests/test-launchd-macos.sh`