### PR TITLE
feat: mark messages as read (bridge + MCP)

### DIFF
--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -933,6 +933,16 @@ type ReactRequest struct {
 	Emoji     *string `json:"emoji"`      // reaction emoji; empty string removes the reaction
 }
 
+// MarkReadRequest is the request body for the /api/mark-read endpoint.
+// Marks inbound messages as read (blue ticks for the other party when receipts are enabled).
+// All message_ids must be from the same sender (whatsmeow MarkRead constraint).
+type MarkReadRequest struct {
+	ChatJID    string   `json:"chat_jid"`              // DM or group JID
+	MessageID  string   `json:"message_id,omitempty"`  // single id convenience
+	MessageIDs []string `json:"message_ids,omitempty"` // batch (same sender only)
+	SenderJID  string   `json:"sender_jid,omitempty"`  // required for groups; defaults to chat_jid in DMs
+}
+
 // classifyMediaPath maps a file extension to (whatsmeow upload type, MIME
 // type, persist-side category). Single source of truth for the upload path
 // (which needs the whatsmeow.MediaType + MIME) and the SQLite persist path
@@ -2223,6 +2233,111 @@ func newRESTMux(client *whatsmeow.Client, messageStore *MessageStore, port int, 
 				"message": fmt.Sprintf("Typing indicator set to %v", req.IsTyping),
 			})
 		}
+	}))
+
+	// Handler for marking messages as read (read receipts / blue ticks)
+	mux.HandleFunc("/api/mark-read", auth(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var req MarkReadRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "Invalid request format", http.StatusBadRequest)
+			return
+		}
+		if req.ChatJID == "" {
+			http.Error(w, "chat_jid is required", http.StatusBadRequest)
+			return
+		}
+
+		ids := make([]string, 0, len(req.MessageIDs)+1)
+		ids = append(ids, req.MessageIDs...)
+		if req.MessageID != "" {
+			ids = append(ids, req.MessageID)
+		}
+		// Deduplicate while preserving order
+		seen := make(map[string]struct{}, len(ids))
+		unique := make([]string, 0, len(ids))
+		for _, id := range ids {
+			if id == "" {
+				continue
+			}
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			seen[id] = struct{}{}
+			unique = append(unique, id)
+		}
+		if len(unique) == 0 {
+			http.Error(w, "message_id or message_ids is required", http.StatusBadRequest)
+			return
+		}
+
+		var chatJID types.JID
+		var err error
+		if strings.Contains(req.ChatJID, "@") {
+			chatJID, err = types.ParseJID(req.ChatJID)
+			if err != nil || chatJID.User == "" {
+				http.Error(w, fmt.Sprintf("Invalid chat_jid: %v", err), http.StatusBadRequest)
+				return
+			}
+		} else {
+			chatJID = types.JID{User: req.ChatJID, Server: "s.whatsapp.net"}
+		}
+
+		var senderJID types.JID
+		switch {
+		case req.SenderJID != "":
+			if strings.Contains(req.SenderJID, "@") {
+				senderJID, err = types.ParseJID(req.SenderJID)
+			} else {
+				senderJID = types.JID{User: req.SenderJID, Server: "s.whatsapp.net"}
+			}
+			if err != nil || senderJID.User == "" {
+				http.Error(w, fmt.Sprintf("Invalid sender_jid: %v", err), http.StatusBadRequest)
+				return
+			}
+		case chatJID.Server == types.GroupServer:
+			http.Error(w, "sender_jid is required for group chats", http.StatusBadRequest)
+			return
+		default:
+			// DMs: messages from the peer — chat JID is the sender
+			senderJID = chatJID
+		}
+
+		if !client.IsConnected() {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"success": false,
+				"message": "WhatsApp client is not connected. Please wait for reconnection.",
+			})
+			return
+		}
+
+		msgIDs := make([]types.MessageID, len(unique))
+		for i, id := range unique {
+			msgIDs[i] = types.MessageID(id)
+		}
+
+		fmt.Printf("→ /api/mark-read chat=%q count=%d sender=%q\n", chatJID, len(msgIDs), senderJID)
+		err = client.MarkRead(context.Background(), msgIDs, time.Now(), chatJID, senderJID)
+		w.Header().Set("Content-Type", "application/json")
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"success": false,
+				"message": fmt.Sprintf("Failed to mark read: %v", err),
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": true,
+			"message": fmt.Sprintf("Marked %d message(s) as read", len(msgIDs)),
+			"count":   len(msgIDs),
+		})
 	}))
 
 	return mux

--- a/whatsapp-bridge/main_test.go
+++ b/whatsapp-bridge/main_test.go
@@ -2205,6 +2205,50 @@ func TestReactHandler_NoAuth_Returns401(t *testing.T) {
 	}
 }
 
+// TestMarkReadHandler_MissingFields_Returns400 verifies /api/mark-read validation.
+func TestMarkReadHandler_MissingFields_Returns400(t *testing.T) {
+	const token = "supersecrettoken1234567890abcdef"
+	handler := newRESTMux(newTestClient(&mockLIDStore{}), newTestMessageStore(t), 8080, token, nil)
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"empty body", "{}"},
+		{"missing ids", `{"chat_jid":"15551234567@s.whatsapp.net"}`},
+		{"missing chat", `{"message_id":"3AABCDEF01234567"}`},
+		{"group missing sender", `{"chat_jid":"120363012345678901@g.us","message_id":"3AABCDEF01234567"}`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:8080/api/mark-read", strings.NewReader(tc.body))
+			req.Header.Set("Authorization", "Bearer "+token)
+			req.Header.Set("Content-Type", "application/json")
+			resp := httptest.NewRecorder()
+			handler.ServeHTTP(resp, req)
+			if resp.Code != http.StatusBadRequest {
+				t.Errorf("body=%q: expected 400, got %d body=%s", tc.body, resp.Code, resp.Body.String())
+			}
+		})
+	}
+}
+
+func TestMarkReadHandler_NoAuth_Returns401(t *testing.T) {
+	const token = "supersecrettoken1234567890abcdef"
+	handler := newRESTMux(newTestClient(&mockLIDStore{}), newTestMessageStore(t), 8080, token, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:8080/api/mark-read",
+		strings.NewReader(`{"chat_jid":"15551234567@s.whatsapp.net","message_id":"3AABCDEF01234567"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 without auth, got %d", resp.Code)
+	}
+}
+
 func TestHandleMessage_RegularMessageDoesNotMarkDeleted(t *testing.T) {
 	client := newTestClient(&mockLIDStore{})
 	ms := newTestMessageStore(t)

--- a/whatsapp-mcp-server/main.py
+++ b/whatsapp-mcp-server/main.py
@@ -49,6 +49,9 @@ from whatsapp import (
     send_message as whatsapp_send_message,
 )
 from whatsapp import (
+    mark_as_read as whatsapp_mark_as_read,
+)
+from whatsapp import (
     send_reaction as whatsapp_send_reaction,
 )
 
@@ -358,6 +361,35 @@ def send_reaction(
         A dictionary containing success status and a status message
     """
     success, status_message = whatsapp_send_reaction(recipient, message_id, emoji, from_me, sender_jid)
+    return {"success": success, "message": status_message}
+
+
+@mcp.tool()
+def mark_as_read(
+    chat_jid: str,
+    message_id: str = "",
+    message_ids: list[str] | None = None,
+    sender_jid: str = "",
+) -> dict[str, Any]:
+    """Mark WhatsApp message(s) as read so the sender sees blue ticks / read receipts.
+
+    Prefer this at the start of a turn over reacting 👀 just to show "seen".
+    For group chats, pass sender_jid (who wrote the message). All IDs in one
+    call must be from the same sender.
+
+    Args:
+        chat_jid: The chat JID (e.g. "12025551234@s.whatsapp.net" or a group JID)
+        message_id: Single message ID to mark read
+        message_ids: Optional list of message IDs (same sender only)
+        sender_jid: Required for groups — full JID of the message author.
+                    Optional in DMs (defaults to the chat peer).
+
+    Returns:
+        A dictionary containing success status and a status message
+    """
+    success, status_message = whatsapp_mark_as_read(
+        chat_jid, message_id, message_ids, sender_jid
+    )
     return {"success": success, "message": status_message}
 
 

--- a/whatsapp-mcp-server/whatsapp.py
+++ b/whatsapp-mcp-server/whatsapp.py
@@ -1153,6 +1153,68 @@ def send_reaction(
         return False, f"Unexpected error: {str(e)}"
 
 
+def mark_as_read(
+    chat_jid: str,
+    message_id: str = "",
+    message_ids: list[str] | None = None,
+    sender_jid: str = "",
+) -> tuple[bool, str]:
+    """Mark one or more WhatsApp messages as read (blue ticks / read receipt).
+
+    Args:
+        chat_jid: The chat JID (DM or group).
+        message_id: Single message ID to mark read.
+        message_ids: Optional list of message IDs (same sender only).
+        sender_jid: Required for group chats — JID of who sent the message(s).
+                    For DMs, defaults to chat_jid on the bridge.
+
+    Returns:
+        Tuple of (success, status_message).
+    """
+    try:
+        if not chat_jid:
+            return False, "chat_jid must be provided"
+
+        ids: list[str] = []
+        if message_ids:
+            ids.extend([mid for mid in message_ids if mid])
+        if message_id:
+            ids.append(message_id)
+        # Deduplicate
+        seen: set[str] = set()
+        unique: list[str] = []
+        for mid in ids:
+            if mid not in seen:
+                seen.add(mid)
+                unique.append(mid)
+        if not unique:
+            return False, "message_id or message_ids must be provided"
+
+        url = f"{WHATSAPP_API_BASE_URL}/mark-read"
+        payload: dict[str, Any] = {
+            "chat_jid": chat_jid,
+            "message_ids": unique,
+        }
+        if sender_jid:
+            payload["sender_jid"] = sender_jid
+
+        response = requests.post(url, json=payload, headers=_bridge_headers())
+
+        if response.status_code == 200:
+            result = response.json()
+            if result.get("success"):
+                return True, result.get("message", "Marked as read")
+            return False, result.get("message", "Unknown error")
+        return False, f"Error: HTTP {response.status_code} - {response.text}"
+
+    except requests.RequestException as e:
+        return False, f"Request error: {str(e)}"
+    except json.JSONDecodeError:
+        return False, f"Error parsing response: {response.text}"
+    except Exception as e:
+        return False, f"Unexpected error: {str(e)}"
+
+
 def download_media(message_id: str, chat_jid: str) -> str | None:
     """Download media from a message and return the local file path.
 


### PR DESCRIPTION
Add POST /api/mark-read (whatsmeow MarkRead) and MCP mark_as_read so agents can send blue-tick read receipts without 👀 on every message. Groups require sender_jid; batch IDs must share one sender.

<!--
Thanks for the PR! A couple of quick checks before you submit:

- Read ROADMAP.md to confirm scope.
- One concern per PR. Split anything bigger.
- Conventional-commit title (feat/fix/chore/docs/ci/refactor/test/perf).
-->

## Summary

<!-- What does this PR do, and why? 1-3 bullets is plenty. -->

-

## Type of change

- [ ] `fix` — bug fix
- [ ] `feat` — new feature
- [ ] `chore` / `docs` / `ci` / `refactor` / `test` / `perf`
- [ ] Breaking change (`!` in commit, or `BREAKING CHANGE:` in body)

## Scope check

- [ ] This change fits the [`ROADMAP.md`](https://github.com/verygoodplugins/whatsapp-mcp/blob/main/ROADMAP.md) "in scope" list, **or** I've opened an issue first to discuss
- [ ] PR is focused on one concern (split if not)
- [ ] PR is ≤ ~300 LOC, **or** justified in the description

## Linked issues

<!-- "Closes #N" / "Refs #N" -->

## Testing

<!-- How did you verify this? Manual steps, new tests, screenshots/logs as needed. -->

- [ ] Added or updated tests
- [ ] Ran `uv run pytest -v` (Python changes)
- [ ] Ran `golangci-lint run` and `go build ./...` (Go changes)
- [ ] Manually exercised the affected code path

## Docs

- [ ] Updated `README.md` (if user-visible)
- [ ] Updated `AGENTS.md` / `CLAUDE.md` (if contributor-visible)
- [ ] Updated tool descriptions in `whatsapp-mcp-server/main.py` (if MCP tools changed)
- [ ] Updated `.env.example` (if env vars changed)

## Risk / rollback

<!-- Anything reviewers should worry about? How do we revert if this misbehaves? -->
