### PR TITLE
feat: add inbound typing/presence tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,69 @@ Download media from a received message.
 - `message_id` (required): ID of the message with media
 - `chat_jid` (required): JID of the chat containing the message
 
+### Typing/Presence Operations
+
+#### `get_typing_state`
+
+Query inbound typing/composing state for WhatsApp chats.
+
+Returns contacts who are currently typing or recording a voice message.
+Useful for detecting when a contact is composing a message before responding
+(e.g., to avoid sending a reaction while they're still typing).
+
+**Parameters:**
+
+- `chat_jid` (optional): Filter results to a specific chat. If not provided,
+  returns all currently-typing contacts across all chats.
+
+**Returns:**
+
+```jsonc
+{
+  "success": true,
+  "typing": [
+    {
+      "chat_jid": "1234567890@s.whatsapp.net",
+      "sender_jid": "9876543210@s.whatsapp.net",
+      "is_typing": true,
+      "media": "",        // "" for text, "audio" for voice recording
+      "updated_at": "2024-01-15T10:30:00Z"
+    }
+  ]
+}
+```
+
+**How it works:**
+
+The bridge marks itself as "available" on connection so that WhatsApp sends
+typing notifications (`events.ChatPresence`). Composing states are tracked
+in-memory and expire after ~30 seconds if no "paused" event arrives.
+
+**Natural Language Examples:**
+
+- "Is anyone typing in the customer support chat?"
+- "Check if the user is composing a message before I react"
+- "Who is currently typing across all my chats?"
+
+**Webhook Integration:**
+
+When `WEBHOOK_URL` is set, typing events are forwarded as they happen:
+
+```json
+{
+  "eventType": "typing",
+  "chatJID": "1234567890@s.whatsapp.net",
+  "senderJID": "9876543210@s.whatsapp.net",
+  "isTyping": true,
+  "media": "",
+  "timestamp": 1705315800
+}
+```
+
+Events are sent for both compose start (`isTyping: true`) and stop
+(`isTyping: false`). The webhook respects the same `WEBHOOK_ENABLED` and
+`X-Bridge-Token` authentication as message webhooks.
+
 ### Chat Operations
 
 All chat tools (`list_chats`, `get_chat`, `get_direct_chat_by_contact`,
@@ -673,12 +736,13 @@ flowchart LR
         HEALTH["/api/health"]
     end
 
-    subgraph MCPTools["MCP Tools (15 total)"]
+    subgraph MCPTools["MCP Tools (16 total)"]
         direction TB
         CONT["Contact Tools<br/>search_contacts, get_contact"]
         MSG["Message Tools<br/>list_messages, send_message, etc."]
         CHAT["Chat Tools<br/>list_chats, get_chat, etc."]
         MEDIA["Media Tools<br/>send_file, download_media, etc."]
+        PRES["Presence Tools<br/>get_typing_state"]
     end
 
     MCPTools -->|HTTP Requests| GoAPI

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -42,6 +42,10 @@ import (
 // Defaults to true. Override with env FORWARD_SELF=false.
 var forwardSelfMessages = getEnvBool("FORWARD_SELF", true)
 
+// typingStore tracks inbound typing/composing presence across all chats.
+// Initialized in main() before the event handler is attached.
+var typingStore *TypingStore
+
 // CLI flag: request a full history sync at pair time.
 // Only meaningful on a fresh pair (whatsapp.db deleted). See the usage block
 // near NewClient for the full rationale and caveats.
@@ -2583,79 +2587,106 @@ func newRESTMux(client *whatsmeow.Client, messageStore *MessageStore, port int, 
 		})
 	}))
 
-	// Handler for sending typing indicator
+	// Handler for typing indicators: GET to query inbound state, POST to send outbound.
 	mux.HandleFunc("/api/typing", auth(func(w http.ResponseWriter, r *http.Request) {
-		// Only allow POST requests
-		if r.Method != http.MethodPost {
-			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-
-		// Parse the request body
-		var req struct {
-			Recipient string `json:"recipient"`
-			IsTyping  bool   `json:"is_typing"`
-		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			http.Error(w, "Invalid request format", http.StatusBadRequest)
-			return
-		}
-
-		// Validate request
-		if req.Recipient == "" {
-			http.Error(w, "Recipient is required", http.StatusBadRequest)
-			return
-		}
-
-		// Create JID for recipient
-		var recipientJID types.JID
-		var err error
-
-		// Check if recipient is a JID
-		if strings.Contains(req.Recipient, "@") {
-			recipientJID, err = types.ParseJID(req.Recipient)
-			if err != nil {
-				w.Header().Set("Content-Type", "application/json")
-				_ = json.NewEncoder(w).Encode(map[string]interface{}{
-					"success": false,
-					"message": fmt.Sprintf("Error parsing JID: %v", err),
-				})
-				return
-			}
-		} else {
-			// Create JID from phone number
-			recipientJID = types.JID{
-				User:   req.Recipient,
-				Server: "s.whatsapp.net",
-			}
-		}
-
-		// Determine the chat presence state
-		var state types.ChatPresence
-		if req.IsTyping {
-			state = types.ChatPresenceComposing
-		} else {
-			state = types.ChatPresencePaused
-		}
-
-		// Send the chat presence update
-		err = client.SendChatPresence(context.Background(), recipientJID, state, types.ChatPresenceMediaText)
-
-		// Set response headers
 		w.Header().Set("Content-Type", "application/json")
 
-		// Send response
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			_ = json.NewEncoder(w).Encode(map[string]interface{}{
-				"success": false,
-				"message": fmt.Sprintf("Failed to send typing indicator: %v", err),
-			})
-		} else {
-			_ = json.NewEncoder(w).Encode(map[string]interface{}{
-				"success": true,
-				"message": fmt.Sprintf("Typing indicator set to %v", req.IsTyping),
-			})
+		switch r.Method {
+		case http.MethodGet:
+			// Query inbound typing state.
+			chatJID := r.URL.Query().Get("chat_jid")
+
+			// Response structure.
+			type TypingResponse struct {
+				ChatJID   string `json:"chat_jid"`
+				SenderJID string `json:"sender_jid"`
+				IsTyping  bool   `json:"is_typing"`
+				Media     string `json:"media,omitempty"`
+				UpdatedAt string `json:"updated_at"`
+			}
+			type GetTypingResponse struct {
+				Success bool             `json:"success"`
+				Typing  []TypingResponse `json:"typing"`
+			}
+
+			var states []*TypingState
+			if chatJID != "" {
+				states = typingStore.GetForChat(chatJID)
+			} else {
+				states = typingStore.ListActive()
+			}
+
+			resp := GetTypingResponse{Success: true, Typing: make([]TypingResponse, 0, len(states))}
+			for _, s := range states {
+				resp.Typing = append(resp.Typing, TypingResponse{
+					ChatJID:   s.ChatJID,
+					SenderJID: s.SenderJID,
+					IsTyping:  s.IsTyping,
+					Media:     s.Media,
+					UpdatedAt: s.UpdatedAt.Format(time.RFC3339),
+				})
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case http.MethodPost:
+			// Send outbound typing indicator (existing behavior).
+			var req struct {
+				Recipient string `json:"recipient"`
+				IsTyping  bool   `json:"is_typing"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, "Invalid request format", http.StatusBadRequest)
+				return
+			}
+
+			if req.Recipient == "" {
+				http.Error(w, "Recipient is required", http.StatusBadRequest)
+				return
+			}
+
+			var recipientJID types.JID
+			var err error
+
+			if strings.Contains(req.Recipient, "@") {
+				recipientJID, err = types.ParseJID(req.Recipient)
+				if err != nil {
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{
+						"success": false,
+						"message": fmt.Sprintf("Error parsing JID: %v", err),
+					})
+					return
+				}
+			} else {
+				recipientJID = types.JID{
+					User:   req.Recipient,
+					Server: "s.whatsapp.net",
+				}
+			}
+
+			var state types.ChatPresence
+			if req.IsTyping {
+				state = types.ChatPresenceComposing
+			} else {
+				state = types.ChatPresencePaused
+			}
+
+			err = client.SendChatPresence(context.Background(), recipientJID, state, types.ChatPresenceMediaText)
+
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"success": false,
+					"message": fmt.Sprintf("Failed to send typing indicator: %v", err),
+				})
+			} else {
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"success": true,
+					"message": fmt.Sprintf("Typing indicator set to %v", req.IsTyping),
+				})
+			}
+
+		default:
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		}
 	}))
 
@@ -2705,6 +2736,9 @@ func main() {
 	logger.Infof("Starting WhatsApp client...")
 
 	logger.Infof("%s", webhookStartupMessage(forwardSelfMessages))
+
+	// Initialize typing store for inbound presence tracking.
+	typingStore = NewTypingStore(DefaultTypingExpiry)
 
 	// Create database connection for storing session data
 	dbLog := waLog.Stdout("Database", "INFO", true)
@@ -2932,6 +2966,34 @@ func main() {
 
 		case *events.Connected:
 			logger.Infof("✓ Successfully connected to WhatsApp servers")
+			// Mark self as available so WhatsApp sends us typing notifications.
+			// Without this, events.ChatPresence is never emitted.
+			if err := client.SendPresence(context.Background(), types.PresenceAvailable); err != nil {
+				logger.Warnf("Failed to send presence available: %v", err)
+			} else {
+				logger.Infof("Marked self as available for typing notifications")
+			}
+
+		case *events.ChatPresence:
+			// Inbound typing/composing state from a contact.
+			chatJID := v.Chat.String()
+			senderJID := v.Sender.String()
+			isTyping := v.State == types.ChatPresenceComposing
+			media := ""
+			if v.Media == types.ChatPresenceMediaAudio {
+				media = "audio"
+			}
+
+			_, changed := typingStore.Update(chatJID, senderJID, isTyping, media)
+			if changed {
+				state := "paused"
+				if isTyping {
+					state = "composing"
+				}
+				logger.Debugf("Typing state: %s is %s in %s", senderJID, state, chatJID)
+				// Forward to webhook.
+				SendTypingWebhook(chatJID, senderJID, isTyping, media)
+			}
 
 		case *events.LoggedOut:
 			logger.Warnf("⚠️  Device logged out, please scan QR code to log in again")

--- a/whatsapp-bridge/typing.go
+++ b/whatsapp-bridge/typing.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"sync"
+	"time"
+
+	"go.mau.fi/whatsmeow/types"
+)
+
+// TypingState represents the composing state of a user in a chat.
+type TypingState struct {
+	ChatJID   string    `json:"chat_jid"`
+	SenderJID string    `json:"sender_jid"`
+	IsTyping  bool      `json:"is_typing"`
+	Media     string    `json:"media,omitempty"` // "" for text, "audio" for voice recording
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// typingKey creates a unique key for a chat+sender combination.
+func typingKey(chatJID, senderJID string) string {
+	return chatJID + "|" + senderJID
+}
+
+// TypingStore tracks inbound typing/composing presence per chat and sender.
+// WhatsApp sends "composing" when a contact starts typing and "paused" when
+// they stop. If no "paused" arrives (e.g. network hiccup), stale entries are
+// expired after a timeout.
+type TypingStore struct {
+	mu      sync.RWMutex
+	entries map[string]*TypingState
+	expiry  time.Duration
+}
+
+// DefaultTypingExpiry is how long a "composing" state lives before auto-expiry.
+// WhatsApp's UI typically shows typing for ~10-15 seconds; we use 30 seconds
+// to be conservative while still cleaning up stale entries.
+const DefaultTypingExpiry = 30 * time.Second
+
+// NewTypingStore creates a new typing state store with the given expiry.
+func NewTypingStore(expiry time.Duration) *TypingStore {
+	ts := &TypingStore{
+		entries: make(map[string]*TypingState),
+		expiry:  expiry,
+	}
+	// Start background cleanup goroutine.
+	go ts.cleanupLoop()
+	return ts
+}
+
+// cleanupLoop periodically removes expired entries.
+func (ts *TypingStore) cleanupLoop() {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	for range ticker.C {
+		ts.cleanup()
+	}
+}
+
+// cleanup removes all expired entries.
+func (ts *TypingStore) cleanup() {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	now := time.Now()
+	for key, state := range ts.entries {
+		if state.IsTyping && now.Sub(state.UpdatedAt) > ts.expiry {
+			delete(ts.entries, key)
+		}
+	}
+}
+
+// Update records a typing state change for a chat/sender. Returns the previous
+// state (nil if none) and whether this is a state change worth notifying about.
+func (ts *TypingStore) Update(chatJID, senderJID string, isTyping bool, media string) (prev *TypingState, changed bool) {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+
+	key := typingKey(chatJID, senderJID)
+	now := time.Now()
+
+	existing := ts.entries[key]
+	if existing != nil {
+		// Copy previous state for return.
+		prevCopy := *existing
+		prev = &prevCopy
+	}
+
+	newState := &TypingState{
+		ChatJID:   chatJID,
+		SenderJID: senderJID,
+		IsTyping:  isTyping,
+		Media:     media,
+		UpdatedAt: now,
+	}
+
+	if isTyping {
+		ts.entries[key] = newState
+		// Changed if no previous state or was not typing.
+		changed = prev == nil || !prev.IsTyping
+	} else {
+		// "Paused" clears the entry.
+		delete(ts.entries, key)
+		// Changed if there was a previous typing state.
+		changed = prev != nil && prev.IsTyping
+	}
+
+	return prev, changed
+}
+
+// Get returns the current typing state for a chat/sender, or nil if not typing.
+// Expired entries are treated as non-existent.
+func (ts *TypingStore) Get(chatJID, senderJID string) *TypingState {
+	ts.mu.RLock()
+	defer ts.mu.RUnlock()
+
+	key := typingKey(chatJID, senderJID)
+	state := ts.entries[key]
+	if state == nil {
+		return nil
+	}
+	// Check expiry.
+	if time.Since(state.UpdatedAt) > ts.expiry {
+		return nil
+	}
+	// Return a copy.
+	stateCopy := *state
+	return &stateCopy
+}
+
+// GetForChat returns all currently-typing senders in a chat.
+func (ts *TypingStore) GetForChat(chatJID string) []*TypingState {
+	ts.mu.RLock()
+	defer ts.mu.RUnlock()
+
+	now := time.Now()
+	var result []*TypingState
+	for _, state := range ts.entries {
+		if state.ChatJID == chatJID && state.IsTyping && now.Sub(state.UpdatedAt) <= ts.expiry {
+			stateCopy := *state
+			result = append(result, &stateCopy)
+		}
+	}
+	return result
+}
+
+// ListActive returns all currently-typing states across all chats.
+func (ts *TypingStore) ListActive() []*TypingState {
+	ts.mu.RLock()
+	defer ts.mu.RUnlock()
+
+	now := time.Now()
+	var result []*TypingState
+	for _, state := range ts.entries {
+		if state.IsTyping && now.Sub(state.UpdatedAt) <= ts.expiry {
+			stateCopy := *state
+			result = append(result, &stateCopy)
+		}
+	}
+	return result
+}
+
+// TypingStateFromJIDs converts whatsmeow JIDs to a TypingState.
+func TypingStateFromJIDs(chat, sender types.JID, isTyping bool, media string) *TypingState {
+	return &TypingState{
+		ChatJID:   chat.String(),
+		SenderJID: sender.String(),
+		IsTyping:  isTyping,
+		Media:     media,
+		UpdatedAt: time.Now(),
+	}
+}

--- a/whatsapp-bridge/typing_test.go
+++ b/whatsapp-bridge/typing_test.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTypingStore_UpdateAndGet(t *testing.T) {
+	store := &TypingStore{
+		entries: make(map[string]*TypingState),
+		expiry:  30 * time.Second,
+	}
+
+	// Initially, no typing state.
+	if got := store.Get("chat1", "sender1"); got != nil {
+		t.Errorf("expected nil for non-existent state, got %+v", got)
+	}
+
+	// Update with composing state.
+	prev, changed := store.Update("chat1", "sender1", true, "")
+	if prev != nil {
+		t.Errorf("expected nil prev for first update, got %+v", prev)
+	}
+	if !changed {
+		t.Error("expected changed=true for first composing update")
+	}
+
+	// Get should return the state.
+	state := store.Get("chat1", "sender1")
+	if state == nil {
+		t.Fatal("expected state after update, got nil")
+	}
+	if !state.IsTyping {
+		t.Error("expected IsTyping=true")
+	}
+	if state.ChatJID != "chat1" {
+		t.Errorf("expected ChatJID=chat1, got %s", state.ChatJID)
+	}
+	if state.SenderJID != "sender1" {
+		t.Errorf("expected SenderJID=sender1, got %s", state.SenderJID)
+	}
+
+	// Update again with composing - not a change since already typing.
+	_, changed = store.Update("chat1", "sender1", true, "")
+	if changed {
+		t.Error("expected changed=false for duplicate composing update")
+	}
+
+	// Update with paused state.
+	prev, changed = store.Update("chat1", "sender1", false, "")
+	if prev == nil {
+		t.Error("expected non-nil prev for paused update")
+	}
+	if !prev.IsTyping {
+		t.Error("expected prev.IsTyping=true")
+	}
+	if !changed {
+		t.Error("expected changed=true for paused update")
+	}
+
+	// Get should return nil after pause.
+	if got := store.Get("chat1", "sender1"); got != nil {
+		t.Errorf("expected nil after pause, got %+v", got)
+	}
+}
+
+func TestTypingStore_UpdateWithMedia(t *testing.T) {
+	store := &TypingStore{
+		entries: make(map[string]*TypingState),
+		expiry:  30 * time.Second,
+	}
+
+	store.Update("chat1", "sender1", true, "audio")
+
+	state := store.Get("chat1", "sender1")
+	if state == nil {
+		t.Fatal("expected state, got nil")
+	}
+	if state.Media != "audio" {
+		t.Errorf("expected Media=audio, got %s", state.Media)
+	}
+}
+
+func TestTypingStore_GetForChat(t *testing.T) {
+	store := &TypingStore{
+		entries: make(map[string]*TypingState),
+		expiry:  30 * time.Second,
+	}
+
+	// Add multiple senders to same chat.
+	store.Update("chat1", "sender1", true, "")
+	store.Update("chat1", "sender2", true, "audio")
+	store.Update("chat2", "sender3", true, "")
+
+	states := store.GetForChat("chat1")
+	if len(states) != 2 {
+		t.Errorf("expected 2 states for chat1, got %d", len(states))
+	}
+
+	// Check that we got the right senders.
+	senders := make(map[string]bool)
+	for _, s := range states {
+		senders[s.SenderJID] = true
+	}
+	if !senders["sender1"] || !senders["sender2"] {
+		t.Errorf("expected sender1 and sender2, got %v", senders)
+	}
+}
+
+func TestTypingStore_ListActive(t *testing.T) {
+	store := &TypingStore{
+		entries: make(map[string]*TypingState),
+		expiry:  30 * time.Second,
+	}
+
+	store.Update("chat1", "sender1", true, "")
+	store.Update("chat2", "sender2", true, "audio")
+
+	states := store.ListActive()
+	if len(states) != 2 {
+		t.Errorf("expected 2 active states, got %d", len(states))
+	}
+}
+
+func TestTypingStore_Expiry(t *testing.T) {
+	store := &TypingStore{
+		entries: make(map[string]*TypingState),
+		expiry:  50 * time.Millisecond,
+	}
+
+	store.Update("chat1", "sender1", true, "")
+
+	// Should exist immediately.
+	if got := store.Get("chat1", "sender1"); got == nil {
+		t.Error("expected state immediately after update")
+	}
+
+	// Wait for expiry.
+	time.Sleep(60 * time.Millisecond)
+
+	// Should be expired.
+	if got := store.Get("chat1", "sender1"); got != nil {
+		t.Errorf("expected nil after expiry, got %+v", got)
+	}
+}
+
+func TestTypingStore_CleanupRemovesExpired(t *testing.T) {
+	store := &TypingStore{
+		entries: make(map[string]*TypingState),
+		expiry:  50 * time.Millisecond,
+	}
+
+	store.Update("chat1", "sender1", true, "")
+
+	// Entry should exist.
+	if len(store.entries) != 1 {
+		t.Errorf("expected 1 entry, got %d", len(store.entries))
+	}
+
+	// Wait for expiry.
+	time.Sleep(60 * time.Millisecond)
+
+	// Run cleanup.
+	store.cleanup()
+
+	// Entry should be removed.
+	if len(store.entries) != 0 {
+		t.Errorf("expected 0 entries after cleanup, got %d", len(store.entries))
+	}
+}
+
+func TestTypingStore_PausedNotChanged(t *testing.T) {
+	store := &TypingStore{
+		entries: make(map[string]*TypingState),
+		expiry:  30 * time.Second,
+	}
+
+	// Paused on non-existent entry is not a change.
+	_, changed := store.Update("chat1", "sender1", false, "")
+	if changed {
+		t.Error("expected changed=false for paused on non-existent entry")
+	}
+}

--- a/whatsapp-bridge/webhook.go
+++ b/whatsapp-bridge/webhook.go
@@ -213,5 +213,70 @@ func SendReactionWebhook(sender, chatJID string, isFromMe bool, messageID, react
 	})
 }
 
+// TypingWebhookPayload represents typing/composing events sent to the webhook.
+type TypingWebhookPayload struct {
+	EventType string `json:"eventType"`
+	ChatJID   string `json:"chatJID"`
+	SenderJID string `json:"senderJID"`
+	IsTyping  bool   `json:"isTyping"`
+	Media     string `json:"media,omitempty"` // "" for text, "audio" for voice recording
+	Timestamp int64  `json:"timestamp"`
+}
+
+// SendTypingWebhook sends a typing state change to the webhook endpoint.
+func SendTypingWebhook(chatJID, senderJID string, isTyping bool, media string) {
+	if !webhooksEnabled() {
+		return
+	}
+
+	webhookURL := os.Getenv("WEBHOOK_URL")
+	explicitlyConfigured := webhookURL != ""
+	if !explicitlyConfigured {
+		webhookURL = defaultWebhookURL
+	}
+
+	payload := TypingWebhookPayload{
+		EventType: "typing",
+		ChatJID:   chatJID,
+		SenderJID: senderJID,
+		IsTyping:  isTyping,
+		Media:     media,
+		Timestamp: time.Now().Unix(),
+	}
+
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		fmt.Printf("Error marshaling typing webhook payload: %v\n", err)
+		return
+	}
+
+	req, err := http.NewRequest(http.MethodPost, webhookURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		fmt.Printf("Error building typing webhook request: %v\n", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if webhookAuthToken != "" && explicitlyConfigured {
+		req.Header.Set("X-Bridge-Token", webhookAuthToken)
+	}
+
+	resp, err := webhookClient.Do(req)
+	if err != nil {
+		fmt.Printf("Error sending typing webhook: %v\n", err)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	state := "stopped"
+	if isTyping {
+		state = "started"
+	}
+	if resp.StatusCode == 200 {
+		fmt.Printf("✓ Typing webhook sent: %s %s typing in %s\n", senderJID, state, chatJID)
+	} else {
+		fmt.Printf("⚠ Typing webhook failed with status %d\n", resp.StatusCode)
+	}
+}
+
 // In main.go, handleMessage forwards webhooks for messages with text content.
 // It will forward self-sent messages when the env var FORWARD_SELF=true.

--- a/whatsapp-mcp-server/main.py
+++ b/whatsapp-mcp-server/main.py
@@ -29,6 +29,9 @@ from whatsapp import (
     get_sender_name as whatsapp_get_sender_name,
 )
 from whatsapp import (
+    get_typing_state as whatsapp_get_typing_state,
+)
+from whatsapp import (
     list_chats as whatsapp_list_chats,
 )
 from whatsapp import (
@@ -462,6 +465,35 @@ def download_media(message_id: str, chat_jid: str) -> dict[str, Any]:
         return {"success": True, "message": "Media downloaded successfully", "file_path": file_path}
     else:
         return {"success": False, "message": "Failed to download media"}
+
+
+@mcp.tool()
+def get_typing_state(chat_jid: str | None = None) -> dict[str, Any]:
+    """Get current typing/composing state for WhatsApp chats.
+
+    Returns contacts who are currently typing or recording a voice message.
+    Useful for detecting when a contact is composing a message before responding.
+
+    The bridge marks itself as "available" on connection so that WhatsApp sends
+    typing notifications. States expire after ~30 seconds if no "paused" event
+    arrives.
+
+    Args:
+        chat_jid: Optional chat JID to filter results. If not provided, returns
+                  all currently-typing contacts across all chats.
+
+    Returns:
+        A dictionary containing:
+        - success: Whether the query succeeded
+        - typing: List of typing states, each with:
+          - chat_jid: The chat where typing is happening
+          - sender_jid: Who is typing
+          - is_typing: Always true (paused states are not returned)
+          - media: "" for text, "audio" for voice recording
+          - updated_at: ISO-8601 timestamp of when typing started/refreshed
+    """
+    typing_states = whatsapp_get_typing_state(chat_jid)
+    return {"success": True, "typing": typing_states}
 
 
 def shutdown_handler(signum, frame):

--- a/whatsapp-mcp-server/tests/test_typing.py
+++ b/whatsapp-mcp-server/tests/test_typing.py
@@ -1,0 +1,122 @@
+"""Tests for typing/presence state functions."""
+
+import whatsapp
+
+
+class DummyResponse:
+    def __init__(self, status_code=200, payload=None, text="OK"):
+        self.status_code = status_code
+        self._payload = payload or {"success": True, "typing": []}
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+def test_get_typing_state_sends_auth_headers(monkeypatch):
+    """get_typing_state includes authorization headers."""
+    calls = []
+    monkeypatch.setenv("WHATSAPP_BRIDGE_TOKEN", "test-token")
+
+    def fake_get(url, params=None, headers=None):
+        calls.append({"url": url, "params": params, "headers": headers})
+        return DummyResponse()
+
+    monkeypatch.setattr(whatsapp.requests, "get", fake_get)
+
+    whatsapp.get_typing_state()
+
+    assert calls[0]["url"].endswith("/typing")
+    assert calls[0]["headers"] == {"Authorization": "Bearer test-token"}
+
+
+def test_get_typing_state_passes_chat_jid_filter(monkeypatch):
+    """get_typing_state passes chat_jid as query param when provided."""
+    calls = []
+    monkeypatch.setenv("WHATSAPP_BRIDGE_TOKEN", "test-token")
+
+    def fake_get(url, params=None, headers=None):
+        calls.append({"url": url, "params": params, "headers": headers})
+        return DummyResponse()
+
+    monkeypatch.setattr(whatsapp.requests, "get", fake_get)
+
+    whatsapp.get_typing_state(chat_jid="12025551234@s.whatsapp.net")
+
+    assert calls[0]["params"] == {"chat_jid": "12025551234@s.whatsapp.net"}
+
+
+def test_get_typing_state_returns_typing_list(monkeypatch):
+    """get_typing_state returns the typing list from the response."""
+    monkeypatch.setenv("WHATSAPP_BRIDGE_TOKEN", "test-token")
+
+    typing_data = [
+        {
+            "chat_jid": "12025551234@s.whatsapp.net",
+            "sender_jid": "98765432100@s.whatsapp.net",
+            "is_typing": True,
+            "media": "",
+            "updated_at": "2026-08-15T10:30:00Z",
+        }
+    ]
+
+    def fake_get(url, params=None, headers=None):
+        return DummyResponse(payload={"success": True, "typing": typing_data})
+
+    monkeypatch.setattr(whatsapp.requests, "get", fake_get)
+
+    result = whatsapp.get_typing_state()
+
+    assert result == typing_data
+
+
+def test_get_typing_state_returns_empty_on_failure(monkeypatch):
+    """get_typing_state returns empty list on HTTP error."""
+    monkeypatch.setenv("WHATSAPP_BRIDGE_TOKEN", "test-token")
+
+    def fake_get(url, params=None, headers=None):
+        return DummyResponse(status_code=500, payload={}, text="Internal Server Error")
+
+    monkeypatch.setattr(whatsapp.requests, "get", fake_get)
+
+    result = whatsapp.get_typing_state()
+
+    assert result == []
+
+
+def test_get_typing_state_returns_empty_on_success_false(monkeypatch):
+    """get_typing_state returns empty list when success=false."""
+    monkeypatch.setenv("WHATSAPP_BRIDGE_TOKEN", "test-token")
+
+    def fake_get(url, params=None, headers=None):
+        return DummyResponse(payload={"success": False})
+
+    monkeypatch.setattr(whatsapp.requests, "get", fake_get)
+
+    result = whatsapp.get_typing_state()
+
+    assert result == []
+
+
+def test_get_typing_state_with_audio_media(monkeypatch):
+    """get_typing_state correctly returns audio (voice recording) state."""
+    monkeypatch.setenv("WHATSAPP_BRIDGE_TOKEN", "test-token")
+
+    typing_data = [
+        {
+            "chat_jid": "12025551234@s.whatsapp.net",
+            "sender_jid": "98765432100@s.whatsapp.net",
+            "is_typing": True,
+            "media": "audio",
+            "updated_at": "2026-08-15T10:30:00Z",
+        }
+    ]
+
+    def fake_get(url, params=None, headers=None):
+        return DummyResponse(payload={"success": True, "typing": typing_data})
+
+    monkeypatch.setattr(whatsapp.requests, "get", fake_get)
+
+    result = whatsapp.get_typing_state()
+
+    assert result[0]["media"] == "audio"

--- a/whatsapp-mcp-server/uv.lock
+++ b/whatsapp-mcp-server/uv.lock
@@ -1041,7 +1041,7 @@ wheels = [
 
 [[package]]
 name = "whatsapp-mcp-server"
-version = "0.5.0"
+version = "0.6.0"
 source = { virtual = "." }
 dependencies = [
     { name = "anyio" },

--- a/whatsapp-mcp-server/whatsapp.py
+++ b/whatsapp-mcp-server/whatsapp.py
@@ -1255,6 +1255,41 @@ def mark_messages_read(
         return False, f"Unexpected error: {str(e)}"
 
 
+def get_typing_state(chat_jid: str | None = None) -> list[dict[str, Any]]:
+    """Query inbound typing/composing state from the bridge.
+
+    Args:
+        chat_jid: Optional chat JID to filter results. If None, returns all active typing states.
+
+    Returns:
+        List of typing state dictionaries with chat_jid, sender_jid, is_typing, media, updated_at.
+    """
+    try:
+        url = f"{WHATSAPP_API_BASE_URL}/typing"
+        params = {}
+        if chat_jid:
+            params["chat_jid"] = chat_jid
+
+        response = requests.get(url, params=params, headers=_bridge_headers())
+
+        if response.status_code == 200:
+            result = response.json()
+            if result.get("success", False):
+                return result.get("typing", [])
+            return []
+        return []
+
+    except requests.RequestException as e:
+        print(f"Request error while getting typing state: {str(e)}")
+        return []
+    except json.JSONDecodeError:
+        print(f"Error parsing typing state response: {response.text}")
+        return []
+    except Exception as e:
+        print(f"Unexpected error while getting typing state: {str(e)}")
+        return []
+
+
 def download_media(message_id: str, chat_jid: str) -> str | None:
     """Download media from a message and return the local file path.
 


### PR DESCRIPTION
## feat: add inbound typing/presence tracking

Adds support for receiving WhatsApp typing/composing notifications so MCP clients and webhooks can detect when a contact is composing a message.

### Why

Lets a client wait until someone has actually finished composing before it processes or replies. A typing-indicator drop is not “done” on its own; this API is the missing signal.

### Changes

**Bridge (`whatsapp-bridge/`):**
- Call `SendPresence(PresenceAvailable)` on connect to receive typing notifications
- Handle `events.ChatPresence` to track composing/paused state per chat+sender
- Add in-memory `TypingStore` with 30-second auto-expiry
- Extend `GET /api/typing` to query inbound typing state (`POST` unchanged for outbound)
- Add typing webhook events (`eventType: "typing"`)

**MCP Server (`whatsapp-mcp-server/`):**
- Add `get_typing_state` tool

**Tests:**
- Go: `TypingStore` unit tests (update, expiry, cleanup)
- Python: `get_typing_state` API tests

**Docs:**
- README: Typing/Presence Operations section
- Tool docstring for MCP

### API

```
GET /api/typing
GET /api/typing?chat_jid=...
```

Webhook payload:

```json
{"eventType":"typing","chatJID":"...","senderJID":"...","isTyping":true,"media":"","timestamp":1234567890}
```

If WhatsApp does not send typing events, the API returns empty lists.