### PR TITLE
fix(bridge): document filename leaked the sender's absolute path

### DIFF
--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -1444,8 +1444,12 @@ func sendWhatsAppMessage(client *whatsmeow.Client, messageStore *MessageStore, r
 			}
 		case whatsmeow.MediaDocument:
 			msg.DocumentMessage = &waProto.DocumentMessage{
-				Title:         proto.String(mediaPath[strings.LastIndex(mediaPath, "/")+1:]),
-				FileName:      proto.String(mediaPath[strings.LastIndex(mediaPath, "/")+1:]),
+				// outboundFileName, not a manual split on "/": the document
+				// filename travels to the recipient, and on Windows the path
+				// is already backslash-normalised, so the naive split leaks
+				// the whole absolute path. See media_path.go.
+				Title:         proto.String(outboundFileName(mediaPath)),
+				FileName:      proto.String(outboundFileName(mediaPath)),
 				Caption:       proto.String(message),
 				Mimetype:      proto.String(mimeType),
 				URL:           &resp.URL,

--- a/whatsapp-bridge/media_path.go
+++ b/whatsapp-bridge/media_path.go
@@ -141,3 +141,43 @@ func pathHasPrefix(child, parent string) bool {
 	rest := child[len(parent):]
 	return strings.HasPrefix(rest, string(os.PathSeparator))
 }
+
+// outboundFileName returns the name a RECIPIENT should see for an outbound
+// document, given a local media path.
+//
+// This is not cosmetic. The document filename travels to the recipient inside
+// the message, so every character of the path we put here is published. The
+// previous code took everything after the last forward slash:
+//
+//	mediaPath[strings.LastIndex(mediaPath, "/")+1:]
+//
+// On Windows that leaks the entire absolute path. The path handed to the send
+// routine has already been through filepath.EvalSymlinks (see the /api/send
+// handler), which normalises separators to backslash, so LastIndex for "/"
+// returns -1, the slice starts at 0, and the recipient sees something like
+// C:\Users\<name>\.local\share\whatsapp-mcp\outbox\file.zip -- username and
+// home layout included.
+//
+// filepath.Base alone is not enough either: it only honours the separator of
+// the platform it runs on, so a Windows-style path handled by a Linux or macOS
+// build would still come through whole. We split on BOTH separators regardless
+// of GOOS, which is what a filename crossing machines requires.
+//
+// If the path ends in a separator, or is otherwise nameless, we fall back to a
+// neutral constant rather than sending an empty filename.
+func outboundFileName(mediaPath string) string {
+	name := mediaPath
+	if i := strings.LastIndexAny(name, `/\`); i >= 0 {
+		name = name[i+1:]
+	}
+	// Drop a Windows drive prefix such as "C:" left behind by a bare
+	// "C:file.zip" style path, which has no separator at all.
+	if i := strings.LastIndex(name, ":"); i >= 0 {
+		name = name[i+1:]
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "file"
+	}
+	return name
+}

--- a/whatsapp-bridge/media_path_test.go
+++ b/whatsapp-bridge/media_path_test.go
@@ -128,3 +128,63 @@ func TestResolveMediaRootsAcceptsEnvList(t *testing.T) {
 		t.Fatalf("expected 2 roots, got %d", len(roots))
 	}
 }
+
+func TestOutboundFileNameNeverLeaksThePath(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "windows absolute path, the reported leak",
+			in:   `C:\Users\someone\.local\share\whatsapp-mcp\outbox\brief.zip`,
+			want: "brief.zip",
+		},
+		{
+			name: "windows path with spaces and parentheses",
+			in:   `C:\Users\someone\outbox\2026-08-24 pitch (v19).mp4`,
+			want: "2026-08-24 pitch (v19).mp4",
+		},
+		{
+			name: "posix absolute path",
+			in:   "/home/someone/.local/share/whatsapp-mcp/outbox/brief.zip",
+			want: "brief.zip",
+		},
+		{
+			name: "mixed separators, as a hand-written path often is",
+			in:   `C:/Users/someone\outbox/brief.zip`,
+			want: "brief.zip",
+		},
+		{
+			name: "bare name, already safe",
+			in:   "brief.zip",
+			want: "brief.zip",
+		},
+		{
+			name: "drive-relative path with no separator at all",
+			in:   `C:brief.zip`,
+			want: "brief.zip",
+		},
+		{
+			name: "trailing separator yields a neutral fallback, never empty",
+			in:   `C:\Users\someone\outbox\`,
+			want: "file",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := outboundFileName(tc.in)
+			if got != tc.want {
+				t.Fatalf("outboundFileName(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+			// The real invariant: nothing that identifies the machine or the
+			// user survives into the name, on any platform.
+			for _, leak := range []string{"Users", "home", "someone", ":", `\`, "/"} {
+				if strings.Contains(got, leak) {
+					t.Fatalf("outboundFileName(%q) = %q, leaks %q", tc.in, got, leak)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What's wrong

The document filename travels to the recipient inside the message, so every character of the path put there is published. The send path builds it with a manual split on the forward slash (`whatsapp-bridge/main.go`):

```go
Title:    proto.String(mediaPath[strings.LastIndex(mediaPath, "/")+1:]),
FileName: proto.String(mediaPath[strings.LastIndex(mediaPath, "/")+1:]),
```

On **Windows** that leaks the entire absolute path. The path reaching the send routine has already been through `filepath.EvalSymlinks` in the `/api/send` handler, which normalises separators to backslash — so `LastIndex(mediaPath, "/")` returns `-1`, the slice starts at index 0, and the recipient sees the whole path as the document's name:

```
C:\Users\<name>\.local\share\whatsapp-mcp\outbox\file.zip
```

Observed in the wild, not theoretically: a document sent to a group displayed the sender's home directory — username included — as the filename, to every recipient. Renaming the file does not help, because the directory is part of the leaked string.

Only **documents** are affected: video, image and audio messages carry no `FileName` field.

### The fix

`outboundFileName` in `media_path.go`. `filepath.Base` alone is not sufficient — it honours only the separator of the platform it runs on, so a Windows-style path handled by a Linux or macOS build still comes through whole. So it splits on **both** separators regardless of `GOOS`, drops a leftover drive prefix from paths like `C:file.zip` that have no separator at all, and falls back to a neutral constant rather than sending an empty filename.

### Tests

`TestOutboundFileNameNeverLeaksThePath`, table-driven over 7 cases: the reported Windows path, a path with spaces and parentheses, a POSIX path, mixed separators, an already-safe bare name, a drive-relative path with no separator, and a trailing separator. Beyond checking the expected name, each case asserts the real invariant — that nothing identifying the machine or the user (`Users`, `home`, `:`, `\`, `/`) survives into the name on any platform.

`go build ./...` and `go test ./...` pass. Three `TestMigrateLegacy*` tests fail on my machine both with and without this change — Windows file-lock on `t.TempDir()` cleanup, unrelated to this patch.

### Scope

One concern, 3 files, +106/-2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
