### PR TITLE
fix(bridge): preserve message ID in text webhooks

### DIFF
--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -2009,7 +2009,7 @@ func handleMessage(client *whatsmeow.Client, messageStore *MessageStore, msg *ev
 				msg.Info.ID, mediaType, imageMimeType, filename, imageDownloadPath,
 			)
 		} else {
-			SendWebhook(sender, content, chatJID, msg.Info.IsFromMe, quotedMessageId, quotedSender, quotedContent, quotedIsFromMe, mentionedJIDs)
+			SendWebhookWithMessageID(sender, content, chatJID, msg.Info.IsFromMe, quotedMessageId, quotedSender, quotedContent, quotedIsFromMe, mentionedJIDs, msg.Info.ID)
 		}
 	}
 

--- a/whatsapp-bridge/webhook.go
+++ b/whatsapp-bridge/webhook.go
@@ -135,8 +135,16 @@ func sendWebhookPayload(payload WebhookPayload) {
 	}
 }
 
-// SendWebhook sends a text-only message to the webhook endpoint.
+// SendWebhook sends a text-only message to the webhook endpoint. New callers
+// should use SendWebhookWithMessageID so receiver-side idempotency can identify
+// repeated WhatsApp events; this wrapper remains for compatibility.
 func SendWebhook(sender, content, chatJID string, isFromMe bool, quotedMessageId, quotedSender, quotedContent string, quotedIsFromMe *bool, mentionedJIDs []string) {
+	SendWebhookWithMessageID(sender, content, chatJID, isFromMe, quotedMessageId, quotedSender, quotedContent, quotedIsFromMe, mentionedJIDs, "")
+}
+
+// SendWebhookWithMessageID sends a text-only message and preserves the native
+// WhatsApp message ID in the payload for downstream idempotency.
+func SendWebhookWithMessageID(sender, content, chatJID string, isFromMe bool, quotedMessageId, quotedSender, quotedContent string, quotedIsFromMe *bool, mentionedJIDs []string, messageID string) {
 	sendWebhookPayload(WebhookPayload{
 		Sender:          sender,
 		Content:         content,
@@ -147,6 +155,7 @@ func SendWebhook(sender, content, chatJID string, isFromMe bool, quotedMessageId
 		QuotedContent:   quotedContent,
 		QuotedIsFromMe:  quotedIsFromMe,
 		MentionedJIDs:   mentionedJIDs,
+		MessageID:       messageID,
 	})
 }
 

--- a/whatsapp-bridge/webhook_test.go
+++ b/whatsapp-bridge/webhook_test.go
@@ -98,6 +98,28 @@ func TestSendWebhookEnabledByDefault(t *testing.T) {
 	}
 }
 
+// TestSendWebhookWithMessageIDSerializesID verifies text-only inbound messages
+// preserve their WhatsApp message ID so downstream webhook idempotency can
+// discard duplicate WhatsApp event deliveries.
+func TestSendWebhookWithMessageIDSerializesID(t *testing.T) {
+	var payload WebhookPayload
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() { _ = r.Body.Close() }()
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode webhook payload: %v", err)
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	t.Setenv("WEBHOOK_URL", srv.URL)
+	SendWebhookWithMessageID("123@s.whatsapp.net", "hi", "123@s.whatsapp.net", false, "", "", "", nil, nil, "3EB0F00D")
+
+	if payload.MessageID != "3EB0F00D" {
+		t.Fatalf("messageId = %q, want %q", payload.MessageID, "3EB0F00D")
+	}
+}
+
 func TestSendWebhookWithMediaDisabledSkipsMediaIO(t *testing.T) {
 	var received bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Problem

Text-only inbound messages were the one webhook payload shape that dropped WhatsApp's native message ID. `WebhookPayload` already carries `MessageID` (`json:"messageId,omitempty"`), and the media and reaction senders already populate it — but `SendWebhook` left it empty, so text webhooks went out with no `messageId` field at all.

That matters because WhatsApp can deliver the same native event more than once, and each delivery arrives over a **different HTTP request**. A consumer that keys idempotency on transport-level headers (`X-Request-ID` and friends) sees two distinct requests and processes the message twice. Without a stable identifier in the body, there is nothing for the consumer to deduplicate on.

## Change

- `webhook.go` — add `SendWebhookWithMessageID(...)`, which serializes `WebhookPayload.MessageID`. `SendWebhook(...)` is kept as a thin wrapper that passes an empty ID, so every existing caller and any external user of the exported function compiles and behaves exactly as before.
- `main.go` — the text-only branch of `handleMessage` now calls `SendWebhookWithMessageID(..., msg.Info.ID)`, bringing text payloads in line with the media and reaction paths.
- `webhook_test.go` — regression test asserting the serialized text webhook JSON carries `messageId`.

Stable native message IDs let webhook consumers safely deduplicate repeated WhatsApp events: the ID is the same across re-deliveries of one message and different between distinct messages, which is exactly the property transport-level request IDs lack.

## Test

```
$ go test ./...
ok  	whatsapp-client	0.543s

$ go build -o /tmp/whatsapp-client-verify .
(ok)
```

## Scope

Three files, +33/−2, additive and backward compatible. No change to any existing exported signature.
