### PR TITLE
fix(bridge): persist upload metadata for outbound media

### DIFF
--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -1129,6 +1129,21 @@ func classifyMediaPath(mediaPath string) (whatsmeow.MediaType, string, string) {
 	}
 }
 
+// outboundMediaRow derives the columns sendWhatsAppMessage persists for an
+// outbound message: the media category (via classifyMediaPath, so it can't
+// drift from the upload-side classification), the filename, and the upload
+// metadata downloadMedia needs to redownload it later. Returns zero values
+// for a plain text message (mediaPath == ""). Split out as its own function
+// so it's unit-testable without a live whatsmeow.Client.
+func outboundMediaRow(mediaPath string, upload whatsmeow.UploadResponse) (mediaType, filename, url string, mediaKey, fileSHA256, fileEncSHA256 []byte, fileLength uint64) {
+	if mediaPath == "" {
+		return "", "", "", nil, nil, nil, 0
+	}
+	_, _, mediaType = classifyMediaPath(mediaPath)
+	filename = filepath.Base(mediaPath)
+	return mediaType, filename, upload.URL, upload.MediaKey, upload.FileSHA256, upload.FileEncSHA256, upload.FileLength
+}
+
 func buildDisappearingMode() *waProto.DisappearingMode {
 	return &waProto.DisappearingMode{
 		Initiator: waProto.DisappearingMode_CHANGED_IN_CHAT.Enum(),
@@ -1370,6 +1385,10 @@ func sendWhatsAppMessage(client *whatsmeow.Client, messageStore *MessageStore, r
 
 	msg := &waProto.Message{}
 
+	// Populated below when mediaPath != "", then reused both to build the
+	// outgoing proto and to persist media metadata further down.
+	var upload whatsmeow.UploadResponse
+
 	// Check if we have media to send
 	if mediaPath != "" {
 		// Read media file
@@ -1381,12 +1400,25 @@ func sendWhatsAppMessage(client *whatsmeow.Client, messageStore *MessageStore, r
 		mediaType, mimeType, _ := classifyMediaPath(mediaPath)
 
 		// Upload media to WhatsApp servers
-		resp, err := client.Upload(context.Background(), mediaData, mediaType)
+		upload, err = client.Upload(context.Background(), mediaData, mediaType)
 		if err != nil {
 			return false, fmt.Sprintf("Error uploading media: %v", err)
 		}
 
-		fmt.Println("Media uploaded", resp)
+		// Don't log the struct itself — UploadResponse carries MediaKey, the
+		// AES key that decrypts this attachment on the CDN.
+		fmt.Printf("Media uploaded: %s (%d bytes)\n", upload.URL, upload.FileLength)
+
+		// downloadMedia reconstructs DirectPath from the stored URL instead
+		// of persisting it directly (no column for it). extractDirectPathFromURL
+		// keeps the URL's query string on purpose (the CDN auth tokens); strip
+		// it from both sides before comparing so this only fires on an actual
+		// mismatch, not the query string that's expected to differ.
+		derivedPath, _, _ := strings.Cut(extractDirectPathFromURL(upload.URL), "?")
+		directPath, _, _ := strings.Cut(upload.DirectPath, "?")
+		if derivedPath != directPath {
+			fmt.Printf("Warning: upload DirectPath %q does not match path derived from URL %q; redownload of this attachment may fail\n", upload.DirectPath, derivedPath)
+		}
 
 		// Create the appropriate message type based on media type
 		switch mediaType {
@@ -1394,12 +1426,12 @@ func sendWhatsAppMessage(client *whatsmeow.Client, messageStore *MessageStore, r
 			msg.ImageMessage = &waProto.ImageMessage{
 				Caption:       proto.String(message),
 				Mimetype:      proto.String(mimeType),
-				URL:           &resp.URL,
-				DirectPath:    &resp.DirectPath,
-				MediaKey:      resp.MediaKey,
-				FileEncSHA256: resp.FileEncSHA256,
-				FileSHA256:    resp.FileSHA256,
-				FileLength:    &resp.FileLength,
+				URL:           &upload.URL,
+				DirectPath:    &upload.DirectPath,
+				MediaKey:      upload.MediaKey,
+				FileEncSHA256: upload.FileEncSHA256,
+				FileSHA256:    upload.FileSHA256,
+				FileLength:    &upload.FileLength,
 			}
 		case whatsmeow.MediaAudio:
 			// Handle ogg audio files
@@ -1421,12 +1453,12 @@ func sendWhatsAppMessage(client *whatsmeow.Client, messageStore *MessageStore, r
 
 			msg.AudioMessage = &waProto.AudioMessage{
 				Mimetype:      proto.String(mimeType),
-				URL:           &resp.URL,
-				DirectPath:    &resp.DirectPath,
-				MediaKey:      resp.MediaKey,
-				FileEncSHA256: resp.FileEncSHA256,
-				FileSHA256:    resp.FileSHA256,
-				FileLength:    &resp.FileLength,
+				URL:           &upload.URL,
+				DirectPath:    &upload.DirectPath,
+				MediaKey:      upload.MediaKey,
+				FileEncSHA256: upload.FileEncSHA256,
+				FileSHA256:    upload.FileSHA256,
+				FileLength:    &upload.FileLength,
 				Seconds:       proto.Uint32(seconds),
 				PTT:           proto.Bool(true),
 				Waveform:      waveform,
@@ -1435,12 +1467,12 @@ func sendWhatsAppMessage(client *whatsmeow.Client, messageStore *MessageStore, r
 			msg.VideoMessage = &waProto.VideoMessage{
 				Caption:       proto.String(message),
 				Mimetype:      proto.String(mimeType),
-				URL:           &resp.URL,
-				DirectPath:    &resp.DirectPath,
-				MediaKey:      resp.MediaKey,
-				FileEncSHA256: resp.FileEncSHA256,
-				FileSHA256:    resp.FileSHA256,
-				FileLength:    &resp.FileLength,
+				URL:           &upload.URL,
+				DirectPath:    &upload.DirectPath,
+				MediaKey:      upload.MediaKey,
+				FileEncSHA256: upload.FileEncSHA256,
+				FileSHA256:    upload.FileSHA256,
+				FileLength:    &upload.FileLength,
 			}
 		case whatsmeow.MediaDocument:
 			msg.DocumentMessage = &waProto.DocumentMessage{
@@ -1448,13 +1480,18 @@ func sendWhatsAppMessage(client *whatsmeow.Client, messageStore *MessageStore, r
 				FileName:      proto.String(mediaPath[strings.LastIndex(mediaPath, "/")+1:]),
 				Caption:       proto.String(message),
 				Mimetype:      proto.String(mimeType),
-				URL:           &resp.URL,
-				DirectPath:    &resp.DirectPath,
-				MediaKey:      resp.MediaKey,
-				FileEncSHA256: resp.FileEncSHA256,
-				FileSHA256:    resp.FileSHA256,
-				FileLength:    &resp.FileLength,
+				URL:           &upload.URL,
+				DirectPath:    &upload.DirectPath,
+				MediaKey:      upload.MediaKey,
+				FileEncSHA256: upload.FileEncSHA256,
+				FileSHA256:    upload.FileSHA256,
+				FileLength:    &upload.FileLength,
 			}
+		default:
+			// Unreachable today (classifyMediaPath only returns the four
+			// types above), but fail loudly rather than send an empty proto
+			// while still persisting media metadata for it.
+			return false, fmt.Sprintf("Unsupported media type for %s", mediaPath)
 		}
 	} else if quotedMsgID != "" || len(mentionedJIDs) > 0 {
 		// Quoted reply and/or mentions: use ExtendedTextMessage so we can
@@ -1525,21 +1562,7 @@ func sendWhatsAppMessage(client *whatsmeow.Client, messageStore *MessageStore, r
 			timestamp = time.Now()
 		}
 
-		var mediaType, filename string
-		if mediaPath != "" {
-			filename = filepath.Base(mediaPath)
-			ext := strings.ToLower(strings.TrimPrefix(filepath.Ext(mediaPath), "."))
-			switch ext {
-			case "jpg", "jpeg", "png", "gif", "webp":
-				mediaType = "image"
-			case "ogg":
-				mediaType = "audio"
-			case "mp4", "avi", "mov":
-				mediaType = "video"
-			default:
-				mediaType = "document"
-			}
-		}
+		mediaType, filename, url, mediaKey, fileSHA256, fileEncSHA256, fileLength := outboundMediaRow(mediaPath, upload)
 
 		// Pass empty name so StoreChat preserves any existing resolved
 		// contact/group name; we don't have one available here and
@@ -1549,7 +1572,7 @@ func sendWhatsAppMessage(client *whatsmeow.Client, messageStore *MessageStore, r
 		}
 		if storeErr := messageStore.StoreMessage(
 			resp.ID, chatJID, senderUser, message, timestamp, true,
-			mediaType, filename, "", nil, nil, nil, 0, quotedMsgID,
+			mediaType, filename, url, mediaKey, fileSHA256, fileEncSHA256, fileLength, quotedMsgID,
 		); storeErr != nil {
 			fmt.Printf("Warning: failed to persist outbound message: %v\n", storeErr)
 		}
@@ -2113,6 +2136,14 @@ func (d *MediaDownloader) GetMediaType() whatsmeow.MediaType {
 	return d.MediaType
 }
 
+// hasCompleteMediaInfo reports whether a stored message row carries enough
+// media metadata to be downloadable. Extracted so tests can exercise the
+// exact predicate downloadMedia enforces, instead of a hand-copied duplicate
+// that can silently drift from it.
+func hasCompleteMediaInfo(url string, mediaKey, fileSHA256, fileEncSHA256 []byte, fileLength uint64) bool {
+	return url != "" && len(mediaKey) != 0 && len(fileSHA256) != 0 && len(fileEncSHA256) != 0 && fileLength != 0
+}
+
 // Function to download media from a message
 func downloadMedia(client *whatsmeow.Client, messageStore *MessageStore, messageID, chatJID string) (bool, string, string, string, error) {
 	// Query the database for the message including timestamp
@@ -2181,7 +2212,7 @@ func downloadMedia(client *whatsmeow.Client, messageStore *MessageStore, message
 	}
 
 	// If we don't have all the media info we need, we can't download
-	if url == "" || len(mediaKey) == 0 || len(fileSHA256) == 0 || len(fileEncSHA256) == 0 || fileLength == 0 {
+	if !hasCompleteMediaInfo(url, mediaKey, fileSHA256, fileEncSHA256, fileLength) {
 		return false, "", "", "", fmt.Errorf("incomplete media information for download")
 	}
 

--- a/whatsapp-bridge/main_test.go
+++ b/whatsapp-bridge/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -2879,5 +2880,157 @@ func TestSendHandler_MentionsField_PassedThrough(t *testing.T) {
 
 	if resp.Code != http.StatusBadRequest {
 		t.Errorf("expected 400 for empty recipient with mentions field, got %d", resp.Code)
+	}
+}
+
+// --- Outbound media persistence ---
+//
+// sendWhatsAppMessage needs a live, connected *whatsmeow.Client to reach
+// client.Upload/client.SendMessage, so these tests cover the two pieces
+// that don't: outboundMediaRow, the pure function that derives what gets
+// persisted from an upload response, and StoreMessage's own round-trip
+// through SQLite. Both are checked against hasCompleteMediaInfo, the same
+// predicate downloadMedia uses to decide whether a row is downloadable.
+
+// TestOutboundMediaRow_PopulatedUpload_SatisfiesRedownloadCheck verifies
+// that a populated upload response maps to a downloadable row.
+func TestOutboundMediaRow_PopulatedUpload_SatisfiesRedownloadCheck(t *testing.T) {
+	upload := whatsmeow.UploadResponse{
+		URL:           "https://mmg.whatsapp.net/v/t62.7161-24/sticker.enc",
+		DirectPath:    "/v/t62.7161-24/sticker.enc",
+		MediaKey:      []byte{0x01, 0x02, 0x03, 0x04},
+		FileSHA256:    []byte{0xaa, 0xbb, 0xcc},
+		FileEncSHA256: []byte{0xdd, 0xee, 0xff},
+		FileLength:    30524,
+	}
+
+	mediaType, filename, url, mediaKey, fileSHA256, fileEncSHA256, fileLength := outboundMediaRow("/tmp/wa-test/test-sticker.webp", upload)
+
+	if mediaType != "image" {
+		t.Errorf("mediaType = %q, want %q", mediaType, "image")
+	}
+	if filename != "test-sticker.webp" {
+		t.Errorf("filename = %q, want %q", filename, "test-sticker.webp")
+	}
+	if !hasCompleteMediaInfo(url, mediaKey, fileSHA256, fileEncSHA256, fileLength) {
+		t.Errorf("outboundMediaRow result is incomplete, would fail downloadMedia's check: url=%q keyLen=%d shaLen=%d encShaLen=%d len=%d",
+			url, len(mediaKey), len(fileSHA256), len(fileEncSHA256), fileLength)
+	}
+
+	// Check values, not just non-empty — a FileSHA256/FileEncSHA256 swap
+	// compiles cleanly and hasCompleteMediaInfo alone wouldn't catch it.
+	if url != upload.URL {
+		t.Errorf("url = %q, want %q", url, upload.URL)
+	}
+	if !bytes.Equal(mediaKey, upload.MediaKey) {
+		t.Errorf("mediaKey = %x, want %x", mediaKey, upload.MediaKey)
+	}
+	if !bytes.Equal(fileSHA256, upload.FileSHA256) {
+		t.Errorf("fileSHA256 = %x, want %x (upload.FileSHA256) — check for a FileSHA256/FileEncSHA256 swap", fileSHA256, upload.FileSHA256)
+	}
+	if !bytes.Equal(fileEncSHA256, upload.FileEncSHA256) {
+		t.Errorf("fileEncSHA256 = %x, want %x (upload.FileEncSHA256) — check for a FileSHA256/FileEncSHA256 swap", fileEncSHA256, upload.FileEncSHA256)
+	}
+	if fileLength != upload.FileLength {
+		t.Errorf("fileLength = %d, want %d", fileLength, upload.FileLength)
+	}
+}
+
+// TestOutboundMediaRow_EmptyMediaPath_ReturnsEmpty verifies the text-message
+// case (mediaPath == "") stays a no-media row, matching the previous
+// inline behavior exactly — no ambiguity between "no media" and "upload
+// returned an empty value".
+func TestOutboundMediaRow_EmptyMediaPath_ReturnsEmpty(t *testing.T) {
+	mediaType, filename, url, mediaKey, fileSHA256, fileEncSHA256, fileLength := outboundMediaRow("", whatsmeow.UploadResponse{})
+
+	if mediaType != "" || filename != "" {
+		t.Errorf("expected empty mediaType/filename for mediaPath=\"\", got mediaType=%q filename=%q", mediaType, filename)
+	}
+	if hasCompleteMediaInfo(url, mediaKey, fileSHA256, fileEncSHA256, fileLength) {
+		t.Fatalf("expected incomplete media info for a text message, got a complete row")
+	}
+}
+
+// queryMediaFields reads back the columns downloadMedia's own query selects,
+// for the first message stored under a chat JID.
+func queryMediaFields(t *testing.T, ms *MessageStore, chatJID, msgID string) (url string, mediaKey, fileSHA256, fileEncSHA256 []byte, fileLength uint64) {
+	t.Helper()
+	err := ms.db.QueryRow(
+		"SELECT url, media_key, file_sha256, file_enc_sha256, file_length FROM messages WHERE id = ? AND chat_jid = ?",
+		msgID, chatJID,
+	).Scan(&url, &mediaKey, &fileSHA256, &fileEncSHA256, &fileLength)
+	if err != nil {
+		t.Fatalf("failed to query stored message: %v", err)
+	}
+	return
+}
+
+// TestStoreMessage_MediaFields_RoundTrip verifies that populated upload
+// metadata (the shape sendWhatsAppMessage now passes) round-trips through
+// SQLite intact and satisfies hasCompleteMediaInfo. mediaType is "image",
+// not "sticker": the outbound path classifies every .webp as "image" (see
+// main.go's extension switch) — "sticker" is only ever written on the
+// inbound path (extractMediaInfo).
+func TestStoreMessage_MediaFields_RoundTrip(t *testing.T) {
+	ms := newTestMessageStore(t)
+	chatJID := "50372269345@s.whatsapp.net"
+
+	url := "https://mmg.whatsapp.net/v/t62.7161-24/sticker.enc"
+	mediaKey := []byte{0x01, 0x02, 0x03, 0x04}
+	fileSHA256 := []byte{0xaa, 0xbb, 0xcc}
+	fileEncSHA256 := []byte{0xdd, 0xee, 0xff}
+	var fileLength uint64 = 30524
+
+	if err := ms.StoreMessage(
+		"OUTBOUND1", chatJID, "50372269345", "", time.Now(), true,
+		"image", "test-sticker.webp", url, mediaKey, fileSHA256, fileEncSHA256, fileLength, "",
+	); err != nil {
+		t.Fatalf("StoreMessage failed: %v", err)
+	}
+
+	gotURL, gotKey, gotSHA, gotEncSHA, gotLen := queryMediaFields(t, ms, chatJID, "OUTBOUND1")
+	if !hasCompleteMediaInfo(gotURL, gotKey, gotSHA, gotEncSHA, gotLen) {
+		t.Errorf("stored media row is incomplete, would fail downloadMedia's check: url=%q keyLen=%d shaLen=%d encShaLen=%d len=%d",
+			gotURL, len(gotKey), len(gotSHA), len(gotEncSHA), gotLen)
+	}
+
+	// Check values, not just non-empty — same rationale as
+	// TestOutboundMediaRow_PopulatedUpload_SatisfiesRedownloadCheck above.
+	if gotURL != url {
+		t.Errorf("url = %q, want %q", gotURL, url)
+	}
+	if !bytes.Equal(gotKey, mediaKey) {
+		t.Errorf("mediaKey = %x, want %x", gotKey, mediaKey)
+	}
+	if !bytes.Equal(gotSHA, fileSHA256) {
+		t.Errorf("fileSHA256 = %x, want %x — check for a file_sha256/file_enc_sha256 column swap", gotSHA, fileSHA256)
+	}
+	if !bytes.Equal(gotEncSHA, fileEncSHA256) {
+		t.Errorf("fileEncSHA256 = %x, want %x — check for a file_sha256/file_enc_sha256 column swap", gotEncSHA, fileEncSHA256)
+	}
+	if gotLen != fileLength {
+		t.Errorf("fileLength = %d, want %d", gotLen, fileLength)
+	}
+}
+
+// TestStoreMessage_EmptyMediaFields_FailsRedownloadCheck documents the shape
+// sendWhatsAppMessage used to pass unconditionally ("", nil, nil, nil, 0)
+// regardless of what client.Upload actually returned. A row stored this way
+// must fail hasCompleteMediaInfo — this is what made every outbound
+// attachment un-redownloadable before the fix.
+func TestStoreMessage_EmptyMediaFields_FailsRedownloadCheck(t *testing.T) {
+	ms := newTestMessageStore(t)
+	chatJID := "50372269345@s.whatsapp.net"
+
+	if err := ms.StoreMessage(
+		"OUTBOUND2", chatJID, "50372269345", "", time.Now(), true,
+		"image", "test-sticker.webp", "", nil, nil, nil, 0, "",
+	); err != nil {
+		t.Fatalf("StoreMessage failed: %v", err)
+	}
+
+	gotURL, gotKey, gotSHA, gotEncSHA, gotLen := queryMediaFields(t, ms, chatJID, "OUTBOUND2")
+	if hasCompleteMediaInfo(gotURL, gotKey, gotSHA, gotEncSHA, gotLen) {
+		t.Fatalf("expected incomplete media info (the pre-fix bug shape), got a complete row")
 	}
 }


### PR DESCRIPTION
<!--
Thanks for the PR! A couple of quick checks before you submit:

- Read ROADMAP.md to confirm scope.
- One concern per PR. Split anything bigger.
- Conventional-commit title (feat/fix/chore/docs/ci/refactor/test/perf).
-->

## Summary

- `sendWhatsAppMessage` discarded `url`/`media_key`/`file_sha256`/`file_enc_sha256`/`file_length` when persisting an outbound media message, always passing empty/nil literals to `StoreMessage` instead of the values `client.Upload` had just returned. `downloadMedia`'s completeness check requires all of those fields, so no attachment sent through the bridge (image, video, document) could ever be re-downloaded afterward.
- Confirmed against `messages.db`: every bridge-sent media row had these columns empty, while phone-sent rows (re-synced via the multi-device echo) had them populated. Verified live end-to-end after the fix: send + redownload round-trips a file byte-for-byte.
- Extracted `outboundMediaRow`, a pure function mapping `(mediaPath, whatsmeow.UploadResponse)` to the columns `StoreMessage` persists — the entire surface the bug lived on, now unit-testable without a live client.

## Type of change

- [x] `fix` — bug fix
- [ ] `feat` — new feature
- [ ] `chore` / `docs` / `ci` / `refactor` / `test` / `perf`
- [ ] Breaking change

## Scope check

- [x] This change fits the [`ROADMAP.md`](https://github.com/verygoodplugins/whatsapp-mcp/blob/main/ROADMAP.md) "in scope" list (Bridge stability → media handling), **or** I've opened an issue first to discuss
- [x] PR is focused on one concern (split if not)
- [x] PR is ≤ ~300 LOC, **or** justified in the description

## Linked issues

None — bug fix with a clear reproduction, per CONTRIBUTING.md this doesn't require a prior issue.

## Testing

- [x] Added or updated tests
- [x] Ran `go test ./... -count=1` — full suite green
- [x] Ran `go vet ./...` and `go build ./...` — clean
- [x] Manually exercised the affected code path (live send + redownload against a real WhatsApp account, byte-for-byte match)

Note: `golangci-lint` isn't installed in my environment, so I couldn't run the CI lint gate locally — `gofmt -l .` is clean and `go vet` passes, but CI's lint run is the first real check of that gate.

Two known gaps, called out rather than hidden:
- A future call site that discards `outboundMediaRow`'s return values in favor of hardcoded literals again isn't caught by the tests added here — that would need a fake `whatsmeow.Client`, which this repo doesn't wire up today. Judged low-probability once the mapping has a name and a single call site.
- The new `DirectPath` consistency check only catches a structural URL/DirectPath disagreement at send time, not a CDN auth token expiring before a later redownload attempt — the same limit `downloadMedia` already has on the inbound path.

## Docs

- [ ] Updated `README.md` (if user-visible) — not needed, no API/behavior contract changed, only internal correctness
- [ ] Updated `AGENTS.md` / `CLAUDE.md` — not needed
- [ ] Updated tool descriptions — not needed, no MCP-facing change
- [ ] Updated `.env.example` — not needed, no new env vars

## Risk / rollback

Low risk: the change only affects what gets written to the `messages` table's media columns for outbound sends and adds a `default` case to a switch that's unreachable today. No schema change, no new dependencies. Revertable with a single `git revert`.
